### PR TITLE
Fix analyzers to count the declaration with catch/foreach.

### DIFF
--- a/StyleChecker/StyleChecker.Test/Naming/Underscore/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Naming/Underscore/AnalyzerTest.cs
@@ -61,7 +61,9 @@ namespace StyleChecker.Test.Naming.Underscore
                 Expected(15, 24, "_m"),
                 Expected(16, 18, "_localFunc"),
                 Expected(16, 33, "_v"),
-                Expected(20, 32, "_o"));
+                Expected(20, 32, "_o"),
+                Expected(31, 30, "_e"),
+                Expected(39, 26, "_item"));
             VerifyFix(code, fix);
         }
     }

--- a/StyleChecker/StyleChecker.Test/Naming/Underscore/Code.cs
+++ b/StyleChecker/StyleChecker.Test/Naming/Underscore/Code.cs
@@ -34,5 +34,23 @@ namespace Application
                 Console.WriteLine($"{_o}");
             }
         }
+
+        public void Catch()
+        {
+            try
+            {
+            }
+            catch (Exception _e)
+            {
+                Console.WriteLine($"{_e}");
+            }
+        }
+
+        public void ForEach()
+        {
+            foreach (var _item in new[] { "a", "b", "c" })
+            {
+            }
+        }
     }
 }

--- a/StyleChecker/StyleChecker.Test/Naming/Underscore/CodeFix.cs
+++ b/StyleChecker/StyleChecker.Test/Naming/Underscore/CodeFix.cs
@@ -34,5 +34,23 @@ namespace Application
                 Console.WriteLine($"{o}");
             }
         }
+
+        public void Catch()
+        {
+            try
+            {
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"{e}");
+            }
+        }
+
+        public void ForEach()
+        {
+            foreach (var item in new[] { "a", "b", "c" })
+            {
+            }
+        }
     }
 }

--- a/StyleChecker/StyleChecker/Cleaning/UnusedVariable/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Cleaning/UnusedVariable/Analyzer.cs
@@ -71,6 +71,8 @@ namespace StyleChecker.Cleaning.UnusedVariable
         {
             var all = LocalVariables.DeclarationTokens(root)
                 .Concat(LocalVariables.DesignationTokens(root))
+                .Concat(LocalVariables.CatchTokens(root))
+                .Concat(LocalVariables.ForEachTokens(root))
                 .ToList();
             if (all.Count == 0)
             {

--- a/StyleChecker/StyleChecker/Naming/LocalVariables.cs
+++ b/StyleChecker/StyleChecker/Naming/LocalVariables.cs
@@ -1,9 +1,9 @@
 namespace StyleChecker.Naming
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
 
     /// <summary>
@@ -72,6 +72,54 @@ namespace StyleChecker.Naming
             */
             return root.DescendantNodes()
                 .OfType<SingleVariableDesignationSyntax>()
+                .Select(n => n.Identifier);
+        }
+
+        /// <summary>
+        /// Gets all the tokens of local variables declared with
+        /// ForEachStatement included in the specified compilation unit.
+        /// </summary>
+        /// <param name="root">
+        /// The compilation unit.
+        /// </param>
+        /// <returns>
+        /// All the tokens of local variables.
+        /// </returns>
+        public static IEnumerable<SyntaxToken> ForEachTokens(
+            CompilationUnitSyntax root)
+        {
+            /*
+                ForEach:
+
+                ForEachStatementSyntax
+                  SyntaxToken <- Identifier
+            */
+            return root.DescendantNodes()
+                .OfType<ForEachStatementSyntax>()
+                .Select(n => n.Identifier);
+        }
+
+        /// <summary>
+        /// Gets all the tokens of local variables declared with
+        /// CatchDeclaration included in the specified compilation unit.
+        /// </summary>
+        /// <param name="root">
+        /// The compilation unit.
+        /// </param>
+        /// <returns>
+        /// All the tokens of local variables.
+        /// </returns>
+        public static IEnumerable<SyntaxToken> CatchTokens(
+            CompilationUnitSyntax root)
+        {
+            /*
+                Catch:
+
+                CatchDeclarationSyntax
+                  SyntaxToken <- Identifier
+            */
+            return root.DescendantNodes()
+                .OfType<CatchDeclarationSyntax>()
                 .Select(n => n.Identifier);
         }
 

--- a/StyleChecker/StyleChecker/Naming/ThoughtlessName/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Naming/ThoughtlessName/Analyzer.cs
@@ -22,28 +22,9 @@ namespace StyleChecker.Naming.ThoughtlessName
 
         private const string Category = Categories.Naming;
 
-        private static readonly DiagnosticDescriptor Rule;
+        private static readonly DiagnosticDescriptor Rule = NewRule();
 
-        private static readonly
-            ImmutableHashSet<SpecialType> SinglePrefixTypeSet;
-
-        private static readonly
-            ImmutableHashSet<SpecialType> DoublePrefixTypeSet;
-
-        private static readonly
-            ImmutableDictionary<SpecialType, string> SpecialTypeNameMap;
-
-        static Analyzer()
-        {
-            var localize = Localizers.Of(R.ResourceManager, typeof(R));
-            Rule = new DiagnosticDescriptor(
-                DiagnosticId,
-                localize(nameof(R.Title)),
-                localize(nameof(R.MessageFormat)),
-                Category,
-                DiagnosticSeverity.Warning,
-                isEnabledByDefault: true,
-                description: localize(nameof(R.Description)));
+        private static readonly ImmutableHashSet<SpecialType>
             SinglePrefixTypeSet = new HashSet<SpecialType>()
             {
                 SpecialType.System_Boolean,
@@ -58,6 +39,8 @@ namespace StyleChecker.Naming.ThoughtlessName
                 SpecialType.System_String,
                 SpecialType.System_Decimal,
             }.ToImmutableHashSet();
+
+        private static readonly ImmutableHashSet<SpecialType>
             DoublePrefixTypeSet = new HashSet<SpecialType>()
             {
                 SpecialType.System_SByte,
@@ -65,6 +48,8 @@ namespace StyleChecker.Naming.ThoughtlessName
                 SpecialType.System_UInt32,
                 SpecialType.System_UInt64,
             }.ToImmutableHashSet();
+
+        private static readonly ImmutableDictionary<SpecialType, string>
             SpecialTypeNameMap = new Dictionary<SpecialType, string>()
             {
                 [SpecialType.System_Object] = "object",
@@ -83,7 +68,6 @@ namespace StyleChecker.Naming.ThoughtlessName
                 [SpecialType.System_Double] = "double",
                 [SpecialType.System_String] = "string",
             }.ToImmutableDictionary();
-        }
 
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor>
@@ -98,6 +82,19 @@ namespace StyleChecker.Naming.ThoughtlessName
             context.RegisterSemanticModelAction(AnalyzeModel);
         }
 
+        private static DiagnosticDescriptor NewRule()
+        {
+            var localize = Localizers.Of(R.ResourceManager, typeof(R));
+            return new DiagnosticDescriptor(
+                DiagnosticId,
+                localize(nameof(R.Title)),
+                localize(nameof(R.MessageFormat)),
+                Category,
+                DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                description: localize(nameof(R.Description)));
+        }
+
         private static void AnalyzeModel(
             SemanticModelAnalysisContext context)
         {
@@ -106,8 +103,9 @@ namespace StyleChecker.Naming.ThoughtlessName
                 context.CancellationToken);
             var all = LocalVariables.DeclarationTokens(root)
                 .Concat(LocalVariables.DesignationTokens(root))
-                .Concat(LocalVariables.DesignationTokens(root))
                 .Concat(LocalVariables.ParameterTokens(root))
+                .Concat(LocalVariables.CatchTokens(root))
+                .Concat(LocalVariables.ForEachTokens(root))
                 .ToList();
 
             if (all.Count == 0)

--- a/StyleChecker/StyleChecker/Naming/Underscore/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Naming/Underscore/Analyzer.cs
@@ -19,20 +19,7 @@ namespace StyleChecker.Naming.Underscore
         public const string DiagnosticId = "Underscore";
 
         private const string Category = Categories.Naming;
-        private static readonly DiagnosticDescriptor Rule;
-
-        static Analyzer()
-        {
-            var localize = Localizers.Of(R.ResourceManager, typeof(R));
-            Rule = new DiagnosticDescriptor(
-                DiagnosticId,
-                localize(nameof(R.Title)),
-                localize(nameof(R.MessageFormat)),
-                Category,
-                DiagnosticSeverity.Warning,
-                isEnabledByDefault: true,
-                description: localize(nameof(R.Description)));
-        }
+        private static readonly DiagnosticDescriptor Rule = NewRule();
 
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor>
@@ -47,6 +34,19 @@ namespace StyleChecker.Naming.Underscore
             context.RegisterSyntaxTreeAction(AnalyzeSyntaxTree);
         }
 
+        private static DiagnosticDescriptor NewRule()
+        {
+            var localize = Localizers.Of(R.ResourceManager, typeof(R));
+            return new DiagnosticDescriptor(
+                DiagnosticId,
+                localize(nameof(R.Title)),
+                localize(nameof(R.MessageFormat)),
+                Category,
+                DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                description: localize(nameof(R.Description)));
+        }
+
         private static void AnalyzeSyntaxTree(
             SyntaxTreeAnalysisContext context)
         {
@@ -59,6 +59,8 @@ namespace StyleChecker.Naming.Underscore
                 .Concat(LocalVariables.DesignationTokens(root))
                 .Concat(LocalVariables.ParameterTokens(root))
                 .Concat(LocalVariables.FunctionTokens(root))
+                .Concat(LocalVariables.CatchTokens(root))
+                .Concat(LocalVariables.ForEachTokens(root))
                 .Where(ContainsUndersore)
                 .ToList();
             if (all.Count == 0)


### PR DESCRIPTION
- Fix Underscore, ThoughtlessName and UnusedVariable analyzers
  to count local variables declared with catch or foreach.