### PR TITLE
Fix UnusedVariableAnalyzer to handle variable names starting with @.

### DIFF
--- a/StyleChecker/StyleChecker.Test/Cleaning/UnusedVariable/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Cleaning/UnusedVariable/AnalyzerTest.cs
@@ -54,8 +54,12 @@ namespace StyleChecker.Test.Cleaning.UnusedVariable
                 Expected(15, 29, variableType, "s", neverUsed),
                 Expected(22, 48, variableType, "v", neverUsed),
                 Expected(27, 56, parameterType, "ignored", usedButMarked),
-                Expected(35, 50, parameterType, "unused", unnecessaryMark),
-                Expected(36, 57, parameterType, "unused", unnecessaryMark));
+                Expected(32, 37, parameterType, "@baz", neverUsed),
+                Expected(34, 17, variableType, "@foo", neverUsed),
+                Expected(35, 33, variableType, "@stringFoo", neverUsed),
+                Expected(38, 48, variableType, "@bar", neverUsed),
+                Expected(46, 50, parameterType, "unused", unnecessaryMark),
+                Expected(47, 57, parameterType, "unused", unnecessaryMark));
         }
     }
 }

--- a/StyleChecker/StyleChecker.Test/Cleaning/UnusedVariable/Code.cs
+++ b/StyleChecker/StyleChecker.Test/Cleaning/UnusedVariable/Code.cs
@@ -36,6 +36,17 @@ namespace StyleChecker.Test.Cleaning.UnusedVariable
         {
             Parameter(ignored);
         }
+
+        public void StartWithAt(int @baz, Dictionary<string, string> map)
+        {
+            var @foo = "string";
+            if ("foo" is string @stringFoo)
+            {
+            }
+            if (map.TryGetValue("key", out var @bar))
+            {
+            }
+        }
     }
 
     public abstract class BaseClass

--- a/StyleChecker/StyleChecker.Test/Cleaning/UnusedVariable/Okay.cs
+++ b/StyleChecker/StyleChecker.Test/Cleaning/UnusedVariable/Okay.cs
@@ -73,5 +73,19 @@ namespace StyleChecker.Test.Cleaning.UnusedVariable
             {
             }
         }
+
+        public void StartWithAt(int @baz, Dictionary<string, string> map)
+        {
+            this.used = @baz;
+            var @foo = "string";
+            if (@foo is string @stringFoo)
+            {
+                this.used = int.Parse(@stringFoo);
+            }
+            if (map.TryGetValue("key", out var @bar))
+            {
+                this.used = int.Parse(@bar);
+            }
+        }
     }
 }

--- a/StyleChecker/StyleChecker/Cleaning/UnusedVariable/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Cleaning/UnusedVariable/Analyzer.cs
@@ -81,7 +81,7 @@ namespace StyleChecker.Cleaning.UnusedVariable
             ILocalSymbol[] FindLocalSymbols(SyntaxToken token)
             {
                 var first = model.LookupSymbols(
-                        token.Span.Start, null, token.Text)
+                        token.Span.Start, null, token.ValueText)
                     .OfType<ILocalSymbol>()
                     .FirstOrDefault();
                 return (first != null)
@@ -142,12 +142,14 @@ namespace StyleChecker.Cleaning.UnusedVariable
                     == typeof(UnusedAttribute).FullName;
             void Report(IParameterSymbol p, string m)
             {
+                var token = (p.DeclaringSyntaxReferences.First().GetSyntax()
+                    as ParameterSyntax).Identifier;
                 var location = p.Locations[0];
                 var diagnostic = Diagnostic.Create(
                     Rule,
                     location,
                     R.TheParameter,
-                    p.Name,
+                    token,
                     m);
                 context.ReportDiagnostic(diagnostic);
             }
@@ -208,7 +210,7 @@ namespace StyleChecker.Cleaning.UnusedVariable
             SemanticModel model, SyntaxToken token)
         {
             var first = model.LookupSymbols(
-                    token.Span.Start, null, token.Text)
+                    token.Span.Start, null, token.ValueText)
                 .OfType<ISymbol>()
                 .FirstOrDefault();
             return (first != null)


### PR DESCRIPTION
- Fix UnusedVariableAnalyzer to handle a verbatim identifier, that is
  a variable name starting with the '@' special character.