### PR TITLE
Fix DiscardingReturnValue analyzer to count some methods.

### DIFF
--- a/StyleChecker/StyleChecker.Test/Framework/Diagnostics.cs
+++ b/StyleChecker/StyleChecker.Test/Framework/Diagnostics.cs
@@ -51,6 +51,7 @@ namespace StyleChecker.Test.Framework
                     "System.Private.CoreLib.dll",
                     "System.Console.dll",
                     "System.Runtime.dll",
+                    "System.Collections.Immutable.dll",
                 }
                 .Select(dll => Path.Combine(assemblyPath, dll))
                 .Concat(new[]

--- a/StyleChecker/StyleChecker.Test/Refactoring/DiscardingReturnValue/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/DiscardingReturnValue/AnalyzerTest.cs
@@ -17,6 +17,10 @@ namespace StyleChecker.Test.Refactoring.DiscardingReturnValue
             => Path.Combine(Categories.Refactoring, "DiscardingReturnValue");
 
         [TestMethod]
+        public void Okay()
+            => VerifyDiagnostic(ReadText("Okay"), Atmosphere.Default);
+
+        [TestMethod]
         public void Code()
         {
             var code = ReadText("Code");
@@ -27,7 +31,7 @@ namespace StyleChecker.Test.Refactoring.DiscardingReturnValue
             Result Expected(Belief b) => b.ToResult(
                 Analyzer.DiagnosticId,
                 $"The return value of '{b.Substitute(k => map[k])}' must be "
-                    + "checked.");
+                    + "used.");
 
             VerifyDiagnostic(code, Atmosphere.Default, Expected);
         }

--- a/StyleChecker/StyleChecker.Test/Refactoring/DiscardingReturnValue/Code.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/DiscardingReturnValue/Code.cs
@@ -1,10 +1,12 @@
 namespace StyleChecker.Test.Refactoring.DiscardingReturnValue
 {
+    using System.Collections.Immutable;
     using System.IO;
+    using StyleChecker.Annotations;
 
     public sealed class Code
     {
-        byte[] array = new byte[4];
+        private byte[] array = new byte[4];
 
         public void Read(Stream stream)
         {
@@ -16,6 +18,44 @@ namespace StyleChecker.Test.Refactoring.DiscardingReturnValue
         {
             reader.Read(array, 0, array.Length);
 //@         ^System.IO.BinaryReader.${Read}
+        }
+
+        public void DoNotIgonore(Stream stream)
+        {
+            Read(stream, array);
+//@         ^StyleChecker.Test.Refactoring.DiscardingReturnValue.Code.Read(System.IO.Stream, byte[])
+        }
+
+        [return: DoNotIgnore]
+        public int Read(Stream stream, byte[] buffer)
+        {
+            return stream.Read(buffer, 0, buffer.Length);
+        }
+
+        public void StringClass()
+        {
+            var s = "Hello, World.";
+            s.IndexOf('W');
+//@         ^string.IndexOf(char)
+            s.ToLower();
+//@         ^string.ToLower()
+        }
+
+        public void TypeClass()
+        {
+            var s = "Hello, World.";
+            var t = s.GetType();
+            t.GetMembers();
+//@         ^System.Type.GetMembers()
+        }
+
+        public void ImmutableArrayClass()
+        {
+            ImmutableArray.Create("a");
+//@         ^System.Collections.Immutable.ImmutableArray.Create<T>(T)
+            var b = ImmutableArray.Create("b");
+            b.Add("c");
+//@         ^System.Collections.Immutable.ImmutableArray<T>.Add(T)
         }
     }
 }

--- a/StyleChecker/StyleChecker.Test/Refactoring/DiscardingReturnValue/Okay.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/DiscardingReturnValue/Okay.cs
@@ -1,0 +1,28 @@
+namespace StyleChecker.Test.Refactoring.DiscardingReturnValue
+{
+    using System;
+    using System.Reflection;
+
+    public sealed class Okay
+    {
+        public void StringClass()
+        {
+            var s = "Hello, World.";
+            var array = new char[s.Length];
+            s.CopyTo(0, array, 0, s.Length);
+        }
+
+        public void TypeClass()
+        {
+            var s = "Hello, World.";
+            var t = s.GetType();
+            var b = Type.DefaultBinder;
+            t.InvokeMember(
+                "ToString",
+                BindingFlags.InvokeMethod,
+                b,
+                t,
+                new object[] {});
+        }
+    }
+}

--- a/StyleChecker/StyleChecker.Test/StyleChecker.Test.csproj
+++ b/StyleChecker/StyleChecker.Test/StyleChecker.Test.csproj
@@ -27,6 +27,7 @@
     <Compile Remove="Naming\Underscore\Okay.cs" />
     <Compile Remove="Ordering\PostIncrement\Code.cs" />
     <Compile Remove="Ordering\PostIncrement\CodeFix.cs" />
+    <Compile Remove="Refactoring\DiscardingReturnValue\Okay.cs" />
     <Compile Remove="Refactoring\NotDesignedForExtension\Code.cs" />
     <Compile Remove="Refactoring\NotDesignedForExtension\Okay.cs" />
     <Compile Remove="Refactoring\AssignmentToParameter\Code.cs" />
@@ -102,6 +103,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Ordering\PostIncrement\Code.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Refactoring\DiscardingReturnValue\Okay.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Refactoring\NotDesignedForExtension\Code.cs">

--- a/StyleChecker/StyleChecker/Annotations/DoNotIgnoreAttribute.cs
+++ b/StyleChecker/StyleChecker/Annotations/DoNotIgnoreAttribute.cs
@@ -5,12 +5,12 @@ namespace StyleChecker.Annotations
     using System;
 
     /// <include file='docs.xml'
-    /// path='docs/members[@name="Unused"]/UnusedAttribute/*'/>
+    /// path='docs/members[@name="DoNotIgnore"]/DoNotIgnoreAttribute/*'/>
     [AttributeUsage(
-        AttributeTargets.Parameter,
+        AttributeTargets.ReturnValue,
         Inherited = false,
         AllowMultiple = false)]
-    public sealed class UnusedAttribute : Attribute
+    public sealed class DoNotIgnoreAttribute : Attribute
     {
     }
 }

--- a/StyleChecker/StyleChecker/Annotations/docs.xml
+++ b/StyleChecker/StyleChecker/Annotations/docs.xml
@@ -1,0 +1,36 @@
+<docs>
+  <members name="Unused">
+    <UnusedAttribute>
+      <summary>
+      The annotation for the
+      <a href="https://github.com/maroontress/StyleChecker/blob/master/doc/rules/UnusedVariable.md">UnusedVariable</a>
+      analyzer, which marks a parameter as unused.
+      </summary>
+      <example>
+        <code>
+        public override void CustomizePoint([Unused] object useIfNeeded)
+        {
+        }
+        </code>
+      </example>
+    </UnusedAttribute>
+  </members>
+  <members name="DoNotIgnore">
+    <DoNotIgnoreAttribute>
+      <summary>
+        The annotation for the
+        <a href="https://github.com/maroontress/StyleChecker/blob/master/doc/rules/DiscardingReturnValue.md">DiscardingReturnValue</a>
+        analyzer, which marks a return value as unable to ignore.
+      </summary>
+      <example>
+        <code>
+          [return: DoNotIgnore]
+          public override int Read(byte[] buffer)
+          {
+             return stream.Read(buffer, 0, buffer.Length);
+          }
+        </code>
+      </example>
+    </DoNotIgnoreAttribute>
+  </members>
+</docs>

--- a/StyleChecker/StyleChecker/Refactoring/DiscardingReturnValue/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Refactoring/DiscardingReturnValue/Analyzer.cs
@@ -9,6 +9,7 @@ namespace StyleChecker.Refactoring.DiscardingReturnValue
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
     using Microsoft.CodeAnalysis.Operations;
+    using StyleChecker.Annotations;
     using R = Resources;
 
     /// <summary>
@@ -22,36 +23,20 @@ namespace StyleChecker.Refactoring.DiscardingReturnValue
         /// </summary>
         public const string DiagnosticId = "DiscardingReturnValue";
 
+        private const string Category = Categories.Refactoring;
+
         /// <summary>
         /// The function that takes the fully qualified name of the method
         /// (including its signature) and returns whether the return value of
         /// it is ignorable or not; <c>true</c> if it is not ignorable,
         /// <c>false</c> otherwise.
         /// </summary>
-        public static readonly Func<string, bool> UnignorableReturnValue;
+        private static readonly Func<IMethodSymbol, bool>
+            TargetMethodPredicate = NewTargetMethodPredicate();
 
-        private const string Category = Categories.Refactoring;
-        private static readonly DiagnosticDescriptor Rule;
-
-        static Analyzer()
-        {
-            var localize = Localizers.Of(R.ResourceManager, typeof(R));
-            Rule = new DiagnosticDescriptor(
-                DiagnosticId,
-                localize(nameof(R.Title)),
-                localize(nameof(R.MessageFormat)),
-                Category,
-                DiagnosticSeverity.Warning,
-                isEnabledByDefault: true,
-                description: localize(nameof(R.Description)));
-
-            var methodSet = new HashSet<string>()
-            {
-                "System.IO.Stream.Read(byte[], int, int)",
-                "System.IO.BinaryReader.Read(byte[], int, int)",
-            };
-            UnignorableReturnValue = name => methodSet.Contains(name);
-        }
+        private static readonly DiagnosticDescriptor Rule = NewRule();
+        private static readonly string DoNotIgnoreClassName
+            = typeof(DoNotIgnoreAttribute).FullName;
 
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor>
@@ -66,6 +51,58 @@ namespace StyleChecker.Refactoring.DiscardingReturnValue
             context.RegisterSemanticModelAction(AnalyzeModel);
         }
 
+        private static DiagnosticDescriptor NewRule()
+        {
+            var localize = Localizers.Of(R.ResourceManager, typeof(R));
+            return new DiagnosticDescriptor(
+                DiagnosticId,
+                localize(nameof(R.Title)),
+                localize(nameof(R.MessageFormat)),
+                Category,
+                DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                description: localize(nameof(R.Description)));
+        }
+
+        private static Func<IMethodSymbol, bool> NewTargetMethodPredicate()
+        {
+            var methodNames = new HashSet<string>()
+            {
+                "System.IO.Stream.Read(byte[], int, int)",
+                "System.IO.BinaryReader.Read(byte[], int, int)",
+            };
+            var typeNames = R.TypeNames.Split(
+                    new[] { "\r\n" },
+                    StringSplitOptions.RemoveEmptyEntries)
+                .ToImmutableHashSet();
+            var typePredicates
+                = new Dictionary<string, Func<IMethodSymbol, bool>>
+            {
+                ["System.Type"] = m => !m.Name.Equals("InvokeMember"),
+            };
+            return m =>
+            {
+                if (methodNames.Contains(m.ToString()))
+                {
+                    return true;
+                }
+                var containingType = m.ContainingType.OriginalDefinition;
+                var type = containingType.ToString();
+                if (typeNames.Contains(type))
+                {
+                    return true;
+                }
+                var containingNamespace = m.ContainingNamespace;
+                if (!typePredicates.TryGetValue(
+                    $"{containingNamespace.Name}.{containingType.Name}",
+                    out var predicate))
+                {
+                    return false;
+                }
+                return predicate(m);
+            };
+        }
+
         private static void AnalyzeModel(
             SemanticModelAnalysisContext context)
         {
@@ -76,12 +113,17 @@ namespace StyleChecker.Refactoring.DiscardingReturnValue
             var all = root.DescendantNodes()
                 .OfType<ExpressionStatementSyntax>()
                 .Select(s => s.Expression)
-                .OfType<InvocationExpressionSyntax>()
-                .ToList();
+                .OfType<InvocationExpressionSyntax>();
             if (all.Count() == 0)
             {
                 return;
             }
+            bool IsMarkedAsDoNotIgnore(IMethodSymbol s)
+                => s.GetReturnTypeAttributes()
+                    .Select(d => d.AttributeClass.ToString())
+                    .Where(n => n == DoNotIgnoreClassName)
+                    .Any();
+
             foreach (var invocationExpr in all)
             {
                 var operation = model.GetOperation(invocationExpr);
@@ -90,8 +132,12 @@ namespace StyleChecker.Refactoring.DiscardingReturnValue
                     continue;
                 }
                 var target = invocationOperation.TargetMethod;
-                var targetName = target.ToString();
-                if (!UnignorableReturnValue(targetName))
+                if (target.ReturnsVoid)
+                {
+                    continue;
+                }
+                if (!IsMarkedAsDoNotIgnore(target)
+                    && !TargetMethodPredicate(target))
                 {
                     continue;
                 }
@@ -100,7 +146,7 @@ namespace StyleChecker.Refactoring.DiscardingReturnValue
                 var diagnostic = Diagnostic.Create(
                     Rule,
                     location,
-                    targetName);
+                    target.OriginalDefinition.ToString());
                 context.ReportDiagnostic(diagnostic);
             }
         }

--- a/StyleChecker/StyleChecker/Refactoring/DiscardingReturnValue/Resources.Designer.cs
+++ b/StyleChecker/StyleChecker/Refactoring/DiscardingReturnValue/Resources.Designer.cs
@@ -62,7 +62,7 @@ namespace StyleChecker.Refactoring.DiscardingReturnValue {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The return value that must be checked is discarded..
+        ///   Looks up a localized string similar to The return value that must be used is discarded..
         /// </summary>
         internal static string Description {
             get {
@@ -71,7 +71,7 @@ namespace StyleChecker.Refactoring.DiscardingReturnValue {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The return value of &apos;{0}&apos; must be checked..
+        ///   Looks up a localized string similar to The return value of &apos;{0}&apos; must be used..
         /// </summary>
         internal static string MessageFormat {
             get {
@@ -85,6 +85,26 @@ namespace StyleChecker.Refactoring.DiscardingReturnValue {
         internal static string Title {
             get {
                 return ResourceManager.GetString("Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to string
+        ///System.Collections.Immutable.ImmutableArray
+        ///System.Collections.Immutable.ImmutableArray&lt;T&gt;
+        ///System.Collections.Immutable.ImmutableDictionary
+        ///System.Collections.Immutable.ImmutableDictionary&lt;TKey,TValue&gt;
+        ///System.Collections.Immutable.ImmutableHashSet
+        ///System.Collections.Immutable.ImmutableHashSet&lt;T&gt;
+        ///System.Collections.Immutable.ImmutableList
+        ///System.Collections.Immutable.ImmutableList&lt;T&gt;
+        ///System.Collections.Immutable.ImmutableQueue
+        ///System.Collections.Immutable.ImmutableQueue&lt;T&gt;
+        ///System.Collection [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TypeNames {
+            get {
+                return ResourceManager.GetString("TypeNames", resourceCulture);
             }
         }
     }

--- a/StyleChecker/StyleChecker/Refactoring/DiscardingReturnValue/Resources.resx
+++ b/StyleChecker/StyleChecker/Refactoring/DiscardingReturnValue/Resources.resx
@@ -118,12 +118,16 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description" xml:space="preserve">
-    <value>The return value that must be checked is discarded.</value>
+    <value>The return value that must be used is discarded.</value>
   </data>
   <data name="MessageFormat" xml:space="preserve">
-    <value>The return value of '{0}' must be checked.</value>
+    <value>The return value of '{0}' must be used.</value>
   </data>
   <data name="Title" xml:space="preserve">
     <value>The return value is discarded.</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="TypeNames" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>typenames.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;shift_jis</value>
   </data>
 </root>

--- a/StyleChecker/StyleChecker/Refactoring/DiscardingReturnValue/TypeNames.txt
+++ b/StyleChecker/StyleChecker/Refactoring/DiscardingReturnValue/TypeNames.txt
@@ -1,0 +1,15 @@
+string
+System.Collections.Immutable.ImmutableArray
+System.Collections.Immutable.ImmutableArray<T>
+System.Collections.Immutable.ImmutableDictionary
+System.Collections.Immutable.ImmutableDictionary<TKey,TValue>
+System.Collections.Immutable.ImmutableHashSet
+System.Collections.Immutable.ImmutableHashSet<T>
+System.Collections.Immutable.ImmutableList
+System.Collections.Immutable.ImmutableList<T>
+System.Collections.Immutable.ImmutableQueue
+System.Collections.Immutable.ImmutableQueue<T>
+System.Collections.Immutable.ImmutableSortedDictionary
+System.Collections.Immutable.ImmutableSortedDictionary<TKey,TValue>
+System.Collections.Immutable.ImmutableStack
+System.Collections.Immutable.ImmutableStack<T>

--- a/doc/rules/DiscardingReturnValue.md
+++ b/doc/rules/DiscardingReturnValue.md
@@ -6,18 +6,28 @@ Do not discard the return value of some methods.
 
 ## Description
 
-There are delicate methods that return a regardful value as follows:
+There are delicate methods that return a regardful value,
+or that do not make sense if the return value is discarded.
+This rule reports diagnostic information as a warning similar to
+[CA1806 (Do not ignore method results)][ca1806]\[[1](#ref1)\]
+about discarding the return value of the methods as follows:
+
+- Some `Read` methods returning the number of bytes read actually
+- Some methods of immutable classes (e.g. `string`, `ImmutableArray`, ...)
+- Methods whose return value is annotated with the custom attribute
+
+## Read &mdash; POSIX read(2) style methods
+
+The following methods are covered:
 
 - `System.IO.Stream.Read(byte[], int, int)`
 - `System.IO.BinaryReader.Read(byte[], int, int)`
-
-### Read &mdash; POSIX read(2) style methods
 
 These `read` methods don't guarantee to read requested bytes
 even when the end of the stream has not been reached.
 See the specifications of
 [Stream.Read Method][system.io.stream.read]
-\[[1](#ref1)\], which are quoted as follows:
+\[[2](#ref2)\], which are quoted as follows:
 
 > ### Remarks
 >
@@ -30,7 +40,7 @@ See the specifications of
 
 And the specifications of
 [BinaryReader.Read Method][system.io.binaryreader.read]
-\[[1](#ref1)\], which are quoted as follows:
+\[[2](#ref2)\], which are quoted as follows:
 
 > ### Returns
 >
@@ -65,6 +75,73 @@ while (length > 0)
 // Here, the actual read length is (offset - initialOffset).
 ```
 
+## Methods of immutable types
+
+The following methods that have no side effects
+and that do not make sense if the return value is discarded, are
+subject to the diagnostics:
+
+- all `string` methods (except ones returning `void`)
+- all `System.Type` methods (except ones returning `void`
+  and `InvokeMember` methods)
+- all methods of
+  `ImmutableArray`,
+  `ImmutableDictionary`,
+  `ImmutableHashSet`,
+  `ImmutableList`,
+  `ImmutableQueue`,
+  `ImmutableSortedDictionary`,
+  `ImmutableSortedSet`,
+  `ImmutableStack`
+  types in namespace `System.Collections.Immutable`
+
+The description of [CA1806][ca1806] is quoted as follows:
+
+> Rule Description
+>
+> Unnecessary object creation and the associated garbage collection of
+> the unused object degrade performance.
+
+However, those who discard the return value of the method having no side effects
+are just confused in many cases. For example, the `string` modification methods
+are typical. The specifications of
+[System.String Class][system.string.modifying-string]
+\[[2](#ref2)\]
+are quoted as follows:
+
+> **Important**
+>
+> All string modification methods return a new String object. They don't modify
+> the value of the current instance.
+
+It is important that all modification methods of immutable objects
+always return the new _unshared_ object for every call,
+so discarding the return value of those methods doesn't make sense.
+In the same way, any other methods without side effects also are wasteful
+ if their return value is ignored.
+
+## Methods whose return value is annotated
+
+The methods that are not of the standard API can be covered
+with `DoNotIgnoreAttribute` provided with
+[StyleChecker.Annotations][stylechecker-annotations].
+The methods are covered if the return value is annotated
+with `DoNotIgnoreAttribute` as follows:
+
+```csharp
+using Maroontress.StyleChecker.Annotations;
+
+public class Class
+{
+    [return: DoNotIgnore]
+    public void Method()
+    {
+        return new ImmutableValue();
+    }
+}
+```
+
+
 ## Code fix
 
 The code fix is not provided.
@@ -80,17 +157,30 @@ public void Method()
     byte[] buffer = ...;
 
     reader.Read(buffer, 0, buffer.Length);
+
+    "hello".IndexOf("o");
 }
 ```
 
 ## References
 
 <a id="ref1"></a>
-[1] [Microsoft, _.NET API Browser_][dot-net-api-browser-microsoft]
+[1] [Microsoft, _Code Analysis for Managed Code Warnings_][ca-warnings-microsoft]
 
+<a id="ref2"></a>
+[2] [Microsoft, _.NET API Browser_][dot-net-api-browser-microsoft]
+
+[ca1806]:
+  https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1806-do-not-ignore-method-results?view=vs-2017
 [dot-net-api-browser-microsoft]:
   https://docs.microsoft.com/en-us/dotnet/api/
+[ca-warnings-microsoft]:
+  https://docs.microsoft.com/en-us/visualstudio/code-quality/code-analysis-for-managed-code-warnings?view=vs-2017
 [system.io.stream.read]:
   https://docs.microsoft.com/en-us/dotnet/api/system.io.stream.read?view=netcore-2.1#System_IO_Stream_Read_System_Byte___System_Int32_System_Int32_
 [system.io.binaryreader.read]:
   https://docs.microsoft.com/en-us/dotnet/api/system.io.binaryreader.read?view=netcore-2.1#System_IO_BinaryReader_Read_System_Byte___System_Int32_System_Int32_
+[system.string.modifying-string]:
+  https://docs.microsoft.com/en-us//dotnet/api/system.string?view=netframework-4.7.2#modifying-a-string
+[stylechecker-annotations]:
+  https://www.nuget.org/packages/StyleChecker.Annotations/


### PR DESCRIPTION
- Update StyleChecker.Annotaions with version 1.0.1.
- Fix DiscardingReturnValue analyzer to count the methods whose return
  type are not void and which are of some immutable classes.
- Fix DiscardingReturnValue analyzer to count the methods whose return
  value is annotated with the DoNotIgnore attribute.