### PR TITLE
Fix analyzers throwing a NRE.

### DIFF
--- a/StyleChecker/StyleChecker.Test/Cleaning/UnusedVariable/Okay.cs
+++ b/StyleChecker/StyleChecker.Test/Cleaning/UnusedVariable/Okay.cs
@@ -1,5 +1,6 @@
 namespace StyleChecker.Test.Cleaning.UnusedVariable
 {
+    using System;
     using System.Collections.Generic;
     using System.Runtime.InteropServices;
     using StyleChecker.Annotations;
@@ -85,6 +86,35 @@ namespace StyleChecker.Test.Cleaning.UnusedVariable
             if (map.TryGetValue("key", out var @bar))
             {
                 this.used = int.Parse(@bar);
+            }
+        }
+
+        public void ForEach()
+        {
+            var all = new string[] { "a", "b", "c", };
+            foreach (var e in all)
+            {
+                Console.WriteLine(e);
+            }
+        }
+
+        public void Catch()
+        {
+            try
+            {
+                Console.WriteLine("a");
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.ToString());
+            }
+            try
+            {
+                Console.WriteLine("a");
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("Exception thrown");
             }
         }
     }

--- a/StyleChecker/StyleChecker.Test/Naming/ThoughtlessName/Code.cs
+++ b/StyleChecker/StyleChecker.Test/Naming/ThoughtlessName/Code.cs
@@ -1,7 +1,7 @@
 #pragma warning disable CS0168
 #pragma warning disable CS0219
 
-namespace Application
+namespace StyleChecker.Test.Naming.ThoughtlessName
 {
     using System;
     using System.IO;

--- a/StyleChecker/StyleChecker.Test/Naming/ThoughtlessName/Okay.cs
+++ b/StyleChecker/StyleChecker.Test/Naming/ThoughtlessName/Okay.cs
@@ -1,5 +1,6 @@
-namespace Application
+namespace StyleChecker.Test.Naming.ThoughtlessName
 {
+    using System;
     using System.IO;
     using System.Text;
 
@@ -9,6 +10,35 @@ namespace Application
         {
             var b = new StringBuilder();
             var stream = new MemoryStream();
+        }
+
+        public void ForEach()
+        {
+            var all = new string[] { "a", "b", "c", };
+            foreach (var e in all)
+            {
+                Console.WriteLine(e);
+            }
+        }
+
+        public void Catch()
+        {
+            try
+            {
+                Console.WriteLine("a");
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.ToString());
+            }
+            try
+            {
+                Console.WriteLine("a");
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("Exception thrown");
+            }
         }
     }
 }

--- a/StyleChecker/StyleChecker/Naming/LocalVariables.cs
+++ b/StyleChecker/StyleChecker/Naming/LocalVariables.cs
@@ -144,6 +144,7 @@ namespace StyleChecker.Naming
             */
             return root.DescendantNodes()
                 .OfType<CatchDeclarationSyntax>()
+                .Where(n => n.Identifier != default)
                 .Select(n => n.Identifier);
         }
 


### PR DESCRIPTION
- Fix ThoughtlessName and UnusedVariable analyzers to handle catch
  clauses without an exception variable.