### PR TITLE
Fix the constructor of DiagnosticVerifier class.

### DIFF
--- a/StyleChecker/StyleChecker.Test/Cleaning/ByteOrderMark/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Cleaning/ByteOrderMark/AnalyzerTest.cs
@@ -10,11 +10,8 @@ namespace StyleChecker.Test.Cleaning.ByteOrderMark
     [TestClass]
     public sealed class AnalyzerTest : DiagnosticVerifier
     {
-        private static readonly string BasePath
-            = Path.Combine(Categories.Cleaning, Analyzer.DiagnosticId);
-
         public AnalyzerTest()
-            : base(BasePath, new Analyzer())
+            : base(new Analyzer())
         {
         }
 
@@ -22,11 +19,11 @@ namespace StyleChecker.Test.Cleaning.ByteOrderMark
         public void NotFound()
         {
             var code = @"";
-            var path = Path.Combine(BasePath, "Test0.cs");
+            var path = Path.Combine(BaseDir, "Test0.cs");
             File.Delete(path);
 
             var atmosphere = Atmosphere.Default
-                .WithBasePath(BasePath)
+                .WithBasePath(BaseDir)
                 .WithForceLocationValid(true);
             var result = NewErrorResult(
                 NewLocations(1, 1),
@@ -40,61 +37,61 @@ namespace StyleChecker.Test.Cleaning.ByteOrderMark
         public void Empty()
         {
             var code = @"";
-            var path = Path.Combine(BasePath, "Test0.cs");
+            var path = Path.Combine(BaseDir, "Test0.cs");
             File.WriteAllText(path, code, Encoding.ASCII);
 
             var atmosphere = Atmosphere.Default
-                .WithBasePath(BasePath);
+                .WithBasePath(BaseDir);
             VerifyDiagnostic(code, atmosphere);
         }
 
         [TestMethod]
         public void Okay()
         {
-            var binPath = Path.Combine(BasePath, "Okay.bin");
+            var binPath = Path.Combine(BaseDir, "Okay.bin");
             var code = File.ReadAllText(binPath);
             var bin = File.ReadAllBytes(binPath);
-            var path = Path.Combine(BasePath, "Test0.cs");
+            var path = Path.Combine(BaseDir, "Test0.cs");
             File.WriteAllBytes(path, bin);
 
             var atmosphere = Atmosphere.Default
-                .WithBasePath(BasePath);
+                .WithBasePath(BaseDir);
             VerifyDiagnostic(code, atmosphere);
         }
 
         [TestMethod]
         public void OkayCustomFile()
         {
-            var binPath = Path.Combine(BasePath, "Okay.bin");
+            var binPath = Path.Combine(BaseDir, "Okay.bin");
             var code = File.ReadAllText(binPath);
             var bin = File.ReadAllBytes(binPath);
-            var path = Path.Combine(BasePath, "Test0.cs");
+            var path = Path.Combine(BaseDir, "Test0.cs");
             File.WriteAllBytes(path, bin);
 
-            var customPath = Path.Combine(BasePath, "CustomFile");
+            var customPath = Path.Combine(BaseDir, "CustomFile");
             File.WriteAllBytes(
                 customPath,
-                File.ReadAllBytes(Path.Combine(BasePath, "Okay.bin")));
+                File.ReadAllBytes(Path.Combine(BaseDir, "Okay.bin")));
 
             var configText = ReadText("SpecifyCustomFile", "xml");
 
             var atmosphere = Atmosphere.Default
                 .WithConfigText(configText)
-                .WithBasePath(BasePath);
+                .WithBasePath(BaseDir);
             VerifyDiagnostic(code, atmosphere);
         }
 
         [TestMethod]
         public void FileStartsWithBom()
         {
-            var binPath = Path.Combine(BasePath, "Code.bin");
+            var binPath = Path.Combine(BaseDir, "Code.bin");
             var code = File.ReadAllText(binPath);
             var bin = File.ReadAllBytes(binPath);
-            var path = Path.Combine(BasePath, "Test0.cs");
+            var path = Path.Combine(BaseDir, "Test0.cs");
             File.WriteAllBytes(path, bin);
 
             var atmosphere = Atmosphere.Default
-                .WithBasePath(BasePath)
+                .WithBasePath(BaseDir)
                 .WithForceLocationValid(true);
             var result = NewErrorResult(
                 NewLocations(1, 1),
@@ -106,22 +103,22 @@ namespace StyleChecker.Test.Cleaning.ByteOrderMark
         [TestMethod]
         public void CustomFileStartsWithBom()
         {
-            var binPath = Path.Combine(BasePath, "Okay.bin");
+            var binPath = Path.Combine(BaseDir, "Okay.bin");
             var code = File.ReadAllText(binPath);
             var bin = File.ReadAllBytes(binPath);
-            var path = Path.Combine(BasePath, "Test0.cs");
+            var path = Path.Combine(BaseDir, "Test0.cs");
             File.WriteAllBytes(path, bin);
 
-            var customPath = Path.Combine(BasePath, "CustomFile");
+            var customPath = Path.Combine(BaseDir, "CustomFile");
             File.WriteAllBytes(
                 customPath,
-                File.ReadAllBytes(Path.Combine(BasePath, "Code.bin")));
+                File.ReadAllBytes(Path.Combine(BaseDir, "Code.bin")));
 
             var configText = ReadText("SpecifyCustomFile", "xml");
 
             var atmosphere = Atmosphere.Default
                 .WithConfigText(configText)
-                .WithBasePath(BasePath);
+                .WithBasePath(BaseDir);
 
             var result = NewErrorResult(
                 NewNoLocations(),
@@ -133,17 +130,17 @@ namespace StyleChecker.Test.Cleaning.ByteOrderMark
         private static ResultLocation[] NewNoLocations()
             => Arrays.Create(new ResultLocation(null, -1, -1));
 
-        private static ResultLocation[] NewLocations(int row, int col)
-        {
-            var path = Path.Combine(BasePath, "Test0.cs");
-            return Arrays.Create(new ResultLocation(path, row, col));
-        }
-
         private static Result NewErrorResult(
             ResultLocation[] locations,
             string id,
             string message,
             DiagnosticSeverity severity = DiagnosticSeverity.Warning)
             => new Result(locations, id, message, severity);
+
+        private ResultLocation[] NewLocations(int row, int col)
+        {
+            var path = Path.Combine(BaseDir, "Test0.cs");
+            return Arrays.Create(new ResultLocation(path, row, col));
+        }
     }
 }

--- a/StyleChecker/StyleChecker.Test/Cleaning/RedundantTypedArrayCreation/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Cleaning/RedundantTypedArrayCreation/AnalyzerTest.cs
@@ -1,6 +1,5 @@
 namespace StyleChecker.Test.Cleaning.RedundantTypedArrayCreation
 {
-    using System.IO;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Cleaning.RedundantTypedArrayCreation;
     using StyleChecker.Test.Framework;
@@ -9,11 +8,7 @@ namespace StyleChecker.Test.Cleaning.RedundantTypedArrayCreation
     public sealed class AnalyzerTest : CodeFixVerifier
     {
         public AnalyzerTest()
-            : base(
-                Path.Combine(
-                    Categories.Cleaning, "RedundantTypedArrayCreation"),
-                new Analyzer(),
-                new CodeFixer())
+            : base(new Analyzer(), new CodeFixer())
         {
         }
 

--- a/StyleChecker/StyleChecker.Test/Cleaning/UnusedUsing/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Cleaning/UnusedUsing/AnalyzerTest.cs
@@ -1,7 +1,6 @@
 namespace StyleChecker.Test.Cleaning.UnusedUsing
 {
     using System.Collections.Immutable;
-    using System.IO;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Cleaning.UnusedUsing;
     using StyleChecker.Test.Framework;
@@ -10,9 +9,7 @@ namespace StyleChecker.Test.Cleaning.UnusedUsing
     public sealed class AnalyzerTest : DiagnosticVerifier
     {
         public AnalyzerTest()
-            : base(
-                Path.Combine(Categories.Cleaning, "UnusedUsing"),
-                new Analyzer())
+            : base(new Analyzer())
         {
         }
 

--- a/StyleChecker/StyleChecker.Test/Cleaning/UnusedVariable/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Cleaning/UnusedVariable/AnalyzerTest.cs
@@ -2,7 +2,6 @@ namespace StyleChecker.Test.Cleaning.UnusedVariable
 {
     using System.Collections.Generic;
     using System.Collections.Immutable;
-    using System.IO;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Cleaning.UnusedVariable;
     using StyleChecker.Refactoring;
@@ -12,9 +11,7 @@ namespace StyleChecker.Test.Cleaning.UnusedVariable
     public sealed class AnalyzerTest : DiagnosticVerifier
     {
         public AnalyzerTest()
-            : base(
-                Path.Combine(Categories.Cleaning, "UnusedVariable"),
-                new Analyzer())
+            : base(new Analyzer())
         {
         }
 

--- a/StyleChecker/StyleChecker.Test/Framework/CodeFixVerifier.cs
+++ b/StyleChecker/StyleChecker.Test/Framework/CodeFixVerifier.cs
@@ -22,9 +22,6 @@ namespace StyleChecker.Test.Framework
         /// Initializes a new instance of the <see cref="CodeFixVerifier"/>
         /// class.
         /// </summary>
-        /// <param name="baseDir">
-        /// The base directory to read files.
-        /// </param>
         /// <param name="analyer">
         /// The diagnostic analyzer being tested.
         /// </param>
@@ -32,10 +29,9 @@ namespace StyleChecker.Test.Framework
         /// The CodeFix provider being tested.
         /// </param>
         protected CodeFixVerifier(
-            string baseDir,
             DiagnosticAnalyzer analyer,
             CodeFixProvider codeFixProvider)
-            : base(baseDir, analyer)
+            : base(analyer)
         {
             CodeFixProvider = codeFixProvider;
         }

--- a/StyleChecker/StyleChecker.Test/Framework/DiagnosticVerifier.cs
+++ b/StyleChecker/StyleChecker.Test/Framework/DiagnosticVerifier.cs
@@ -21,17 +21,19 @@ namespace StyleChecker.Test.Framework
         /// Initializes a new instance of the <see cref="DiagnosticVerifier"/>
         /// class.
         /// </summary>
-        /// <param name="baseDir">
-        /// The base directory to read files.
-        /// </param>
         /// <param name="analyer">
         /// The diagnostic analyzer being tested.
         /// </param>
-        protected DiagnosticVerifier(
-            string baseDir, DiagnosticAnalyzer analyer)
+        protected DiagnosticVerifier(DiagnosticAnalyzer analyer)
         {
-            BaseDir = baseDir;
             DiagnosticAnalyzer = analyer;
+            var supported = analyer.SupportedDiagnostics;
+            if (supported.Length == 0)
+            {
+                throw new ArgumentException("no supported diagnostics");
+            }
+            var descriptor = supported[0];
+            BaseDir = Path.Combine(descriptor.Category, descriptor.Id);
         }
 
         /// <summary>

--- a/StyleChecker/StyleChecker.Test/Naming/SingleTypeParameter/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Naming/SingleTypeParameter/AnalyzerTest.cs
@@ -1,6 +1,5 @@
 namespace StyleChecker.Test.Naming.SingleTypeParameter
 {
-    using System.IO;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Naming.SingleTypeParameter;
     using StyleChecker.Test.Framework;
@@ -9,10 +8,7 @@ namespace StyleChecker.Test.Naming.SingleTypeParameter
     public sealed class AnalyzerTest : CodeFixVerifier
     {
         public AnalyzerTest()
-            : base(
-                Path.Combine(Categories.Naming, "SingleTypeParameter"),
-                new Analyzer(),
-                new CodeFixer())
+            : base(new Analyzer(), new CodeFixer())
         {
         }
 

--- a/StyleChecker/StyleChecker.Test/Naming/ThoughtlessName/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Naming/ThoughtlessName/AnalyzerTest.cs
@@ -2,7 +2,6 @@ namespace StyleChecker.Test.Naming.ThoughtlessName
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Naming.ThoughtlessName;
     using StyleChecker.Test.Framework;
@@ -11,9 +10,7 @@ namespace StyleChecker.Test.Naming.ThoughtlessName
     public sealed class AnalyzerTest : DiagnosticVerifier
     {
         public AnalyzerTest()
-            : base(
-                Path.Combine(Categories.Naming, "ThoughtlessName"),
-                new Analyzer())
+            : base(new Analyzer())
         {
         }
 

--- a/StyleChecker/StyleChecker.Test/Naming/Underscore/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Naming/Underscore/AnalyzerTest.cs
@@ -1,6 +1,5 @@
 namespace StyleChecker.Test.Naming.Underscore
 {
-    using System.IO;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Naming.Underscore;
     using StyleChecker.Test.Framework;
@@ -9,10 +8,7 @@ namespace StyleChecker.Test.Naming.Underscore
     public sealed class AnalyzerTest : CodeFixVerifier
     {
         public AnalyzerTest()
-            : base(
-                Path.Combine(Categories.Naming, "Underscore"),
-                new Analyzer(),
-                new CodeFixer())
+            : base(new Analyzer(), new CodeFixer())
         {
         }
 

--- a/StyleChecker/StyleChecker.Test/Ordering/PostIncrement/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Ordering/PostIncrement/AnalyzerTest.cs
@@ -1,6 +1,5 @@
 namespace StyleChecker.Test.Ordering.PostIncrement
 {
-    using System.IO;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Ordering.PostIncrement;
     using StyleChecker.Test.Framework;
@@ -9,10 +8,7 @@ namespace StyleChecker.Test.Ordering.PostIncrement
     public sealed class AnalyzerTest : CodeFixVerifier
     {
         public AnalyzerTest()
-            : base(
-                Path.Combine(Categories.Ordering, "PostIncrement"),
-                new Analyzer(),
-                new CodeFixer())
+            : base(new Analyzer(), new CodeFixer())
         {
         }
 

--- a/StyleChecker/StyleChecker.Test/Refactoring/AssignmentToParameter/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/AssignmentToParameter/AnalyzerTest.cs
@@ -1,6 +1,5 @@
 namespace StyleChecker.Test.Refactoring.AssignmentToParameter
 {
-    using System.IO;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Refactoring.AssignmentToParameter;
     using StyleChecker.Test.Framework;
@@ -9,9 +8,7 @@ namespace StyleChecker.Test.Refactoring.AssignmentToParameter
     public sealed class AnalyzerTest : DiagnosticVerifier
     {
         public AnalyzerTest()
-            : base(
-                Path.Combine(Categories.Refactoring, "AssignmentToParameter"),
-                new Analyzer())
+            : base(new Analyzer())
         {
         }
 

--- a/StyleChecker/StyleChecker.Test/Refactoring/DiscardingReturnValue/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/DiscardingReturnValue/AnalyzerTest.cs
@@ -1,7 +1,6 @@
 namespace StyleChecker.Test.Refactoring.DiscardingReturnValue
 {
     using System.Collections.Generic;
-    using System.IO;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Refactoring.DiscardingReturnValue;
     using StyleChecker.Test.Framework;
@@ -10,9 +9,7 @@ namespace StyleChecker.Test.Refactoring.DiscardingReturnValue
     public sealed class AnalyzerTest : DiagnosticVerifier
     {
         public AnalyzerTest()
-            : base(
-                Path.Combine(Categories.Refactoring, "DiscardingReturnValue"),
-                new Analyzer())
+            : base(new Analyzer())
         {
         }
 

--- a/StyleChecker/StyleChecker.Test/Refactoring/EmptyArrayCreation/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/EmptyArrayCreation/AnalyzerTest.cs
@@ -1,6 +1,5 @@
 namespace StyleChecker.Test.Refactoring.EmptyArrayCreation
 {
-    using System.IO;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Refactoring.EmptyArrayCreation;
     using StyleChecker.Test.Framework;
@@ -9,10 +8,7 @@ namespace StyleChecker.Test.Refactoring.EmptyArrayCreation
     public sealed class AnalyzerTest : CodeFixVerifier
     {
         public AnalyzerTest()
-            : base(
-                Path.Combine(Categories.Refactoring, "EmptyArrayCreation"),
-                new Analyzer(),
-                new CodeFixer())
+            : base(new Analyzer(), new CodeFixer())
         {
         }
 

--- a/StyleChecker/StyleChecker.Test/Refactoring/EqualsNull/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/EqualsNull/AnalyzerTest.cs
@@ -1,6 +1,5 @@
 namespace StyleChecker.Test.Refactoring.EqualsNull
 {
-    using System.IO;
     using Microsoft.CodeAnalysis;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Refactoring.EqualsNull;
@@ -10,10 +9,7 @@ namespace StyleChecker.Test.Refactoring.EqualsNull
     public sealed class AnalyzerTest : CodeFixVerifier
     {
         public AnalyzerTest()
-            : base(
-                Path.Combine(Categories.Refactoring, "EqualsNull"),
-                new Analyzer(),
-                new CodeFixer())
+            : base(new Analyzer(), new CodeFixer())
         {
         }
 

--- a/StyleChecker/StyleChecker.Test/Refactoring/IneffectiveReadByte/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/IneffectiveReadByte/AnalyzerTest.cs
@@ -1,6 +1,5 @@
 namespace StyleChecker.Test.Refactoring.IneffectiveReadByte
 {
-    using System.IO;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Refactoring.IneffectiveReadByte;
     using StyleChecker.Test.Framework;
@@ -9,10 +8,7 @@ namespace StyleChecker.Test.Refactoring.IneffectiveReadByte
     public sealed class AnalyzerTest : CodeFixVerifier
     {
         public AnalyzerTest()
-            : base(
-                Path.Combine(Categories.Refactoring, "IneffectiveReadByte"),
-                new Analyzer(),
-                new CodeFixer())
+            : base(new Analyzer(), new CodeFixer())
         {
         }
 

--- a/StyleChecker/StyleChecker.Test/Refactoring/IsNull/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/IsNull/AnalyzerTest.cs
@@ -1,6 +1,5 @@
 namespace StyleChecker.Test.Refactoring.IsNull
 {
-    using System.IO;
     using Microsoft.CodeAnalysis;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Refactoring.IsNull;
@@ -10,10 +9,7 @@ namespace StyleChecker.Test.Refactoring.IsNull
     public sealed class AnalyzerTest : CodeFixVerifier
     {
         public AnalyzerTest()
-            : base(
-                Path.Combine(Categories.Refactoring, "IsNull"),
-                new Analyzer(),
-                new CodeFixer())
+            : base(new Analyzer(), new CodeFixer())
         {
         }
 

--- a/StyleChecker/StyleChecker.Test/Refactoring/NotDesignedForExtension/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/NotDesignedForExtension/AnalyzerTest.cs
@@ -1,7 +1,6 @@
 namespace StyleChecker.Test.Refactoring.NotDesignedForExtenstion
 {
     using System.Collections.Generic;
-    using System.IO;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Refactoring.NotDesignedForExtension;
     using StyleChecker.Test.Framework;
@@ -10,10 +9,7 @@ namespace StyleChecker.Test.Refactoring.NotDesignedForExtenstion
     public sealed class AnalyzerTest : DiagnosticVerifier
     {
         public AnalyzerTest()
-            : base(
-                Path.Combine(
-                    Categories.Refactoring, "NotDesignedForExtension"),
-                new Analyzer())
+            : base(new Analyzer())
         {
         }
 

--- a/StyleChecker/StyleChecker.Test/Refactoring/StaticGenericClass/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/StaticGenericClass/AnalyzerTest.cs
@@ -1,6 +1,5 @@
 namespace StyleChecker.Test.Refactoring.StaticGenericClass
 {
-    using System.IO;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Refactoring.StaticGenericClass;
     using StyleChecker.Test.Framework;
@@ -9,10 +8,7 @@ namespace StyleChecker.Test.Refactoring.StaticGenericClass
     public sealed class AnalyzerTest : CodeFixVerifier
     {
         public AnalyzerTest()
-            : base(
-                Path.Combine(Categories.Refactoring, "StaticGenericClass"),
-                new Analyzer(),
-                new CodeFixer())
+            : base(new Analyzer(), new CodeFixer())
         {
         }
 

--- a/StyleChecker/StyleChecker.Test/Refactoring/TypeClassParameter/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/TypeClassParameter/AnalyzerTest.cs
@@ -1,7 +1,6 @@
 namespace StyleChecker.Test.Refactoring.TypeClassParameter
 {
     using System.Collections.Generic;
-    using System.IO;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Refactoring.TypeClassParameter;
     using StyleChecker.Test.Framework;
@@ -10,10 +9,7 @@ namespace StyleChecker.Test.Refactoring.TypeClassParameter
     public sealed class AnalyzerTest : CodeFixVerifier
     {
         public AnalyzerTest()
-            : base(
-                Path.Combine(Categories.Refactoring, "TypeClassParameter"),
-                new Analyzer(),
-                new CodeFixer())
+            : base(new Analyzer(), new CodeFixer())
         {
         }
 

--- a/StyleChecker/StyleChecker.Test/Refactoring/UnnecessaryUsing/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/UnnecessaryUsing/AnalyzerTest.cs
@@ -1,6 +1,5 @@
 namespace StyleChecker.Test.Refactoring.UnnecessaryUsing
 {
-    using System.IO;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Refactoring.UnnecessaryUsing;
     using StyleChecker.Test.Framework;
@@ -9,10 +8,7 @@ namespace StyleChecker.Test.Refactoring.UnnecessaryUsing
     public sealed class AnalyzerTest : CodeFixVerifier
     {
         public AnalyzerTest()
-            : base(
-                Path.Combine(Categories.Refactoring, "UnnecessaryUsing"),
-                new Analyzer(),
-                new CodeFixer())
+            : base(new Analyzer(), new CodeFixer())
         {
         }
 

--- a/StyleChecker/StyleChecker.Test/Settings/InvalidConfig/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Settings/InvalidConfig/AnalyzerTest.cs
@@ -1,7 +1,6 @@
 namespace StyleChecker.Test.Settings.InvalidConfig
 {
     using System;
-    using System.IO;
     using Microsoft.CodeAnalysis;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Settings.InvalidConfig;
@@ -11,9 +10,7 @@ namespace StyleChecker.Test.Settings.InvalidConfig
     public sealed class AnalyzerTest : DiagnosticVerifier
     {
         public AnalyzerTest()
-            : base(
-                Path.Combine(Categories.Settings, "InvalidConfig"),
-                new Analyzer())
+            : base(new Analyzer())
         {
         }
 

--- a/StyleChecker/StyleChecker.Test/Size/LongLine/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Size/LongLine/AnalyzerTest.cs
@@ -1,6 +1,5 @@
 namespace StyleChecker.Test.Size.LongLine
 {
-    using System.IO;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Size.LongLine;
     using StyleChecker.Test.Framework;
@@ -9,7 +8,7 @@ namespace StyleChecker.Test.Size.LongLine
     public sealed class AnalyzerTest : DiagnosticVerifier
     {
         public AnalyzerTest()
-            : base(Path.Combine(Categories.Size, "LongLine"), new Analyzer())
+            : base(new Analyzer())
         {
         }
 

--- a/StyleChecker/StyleChecker.Test/Spacing/NoSpaceAfterSemicolon/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Spacing/NoSpaceAfterSemicolon/AnalyzerTest.cs
@@ -1,6 +1,5 @@
 namespace StyleChecker.Test.Spacing.NoSpaceAfterSemicolon
 {
-    using System.IO;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Spacing.NoSpaceAfterSemicolon;
     using StyleChecker.Test.Framework;
@@ -9,10 +8,7 @@ namespace StyleChecker.Test.Spacing.NoSpaceAfterSemicolon
     public sealed class AnalyzerTest : CodeFixVerifier
     {
         public AnalyzerTest()
-            : base(
-                Path.Combine(Categories.Spacing, "NoSpaceAfterSemicolon"),
-                new Analyzer(),
-                new CodeFixer())
+            : base(new Analyzer(), new CodeFixer())
         {
         }
 

--- a/StyleChecker/StyleChecker.Test/Spacing/SpaceBeforeSemicolon/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Spacing/SpaceBeforeSemicolon/AnalyzerTest.cs
@@ -1,6 +1,5 @@
 namespace StyleChecker.Test.Spacing.SpaceBeforeSemicolon
 {
-    using System.IO;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Spacing.SpaceBeforeSemicolon;
     using StyleChecker.Test.Framework;
@@ -9,10 +8,7 @@ namespace StyleChecker.Test.Spacing.SpaceBeforeSemicolon
     public sealed class AnalyzerTest : CodeFixVerifier
     {
         public AnalyzerTest()
-            : base(
-                Path.Combine(Categories.Spacing, "SpaceBeforeSemicolon"),
-                new Analyzer(),
-                new CodeFixer())
+            : base(new Analyzer(), new CodeFixer())
         {
         }
 


### PR DESCRIPTION
- Fix the DiagnosticVerifier constructor to get DiagnosticAnalyzer
  parameter only. The BaseDir property is specified with the first
  descriptor of the analyzer.