### PR TITLE
Enable NullableContextOptions and fix warnings.

### DIFF
--- a/StyleChecker/StyleChecker.Test/Cleaning/ByteOrderMark/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Cleaning/ByteOrderMark/AnalyzerTest.cs
@@ -18,7 +18,7 @@ namespace StyleChecker.Test.Cleaning.ByteOrderMark
         [TestMethod]
         public void NotFound()
         {
-            var code = @"";
+            var code = "";
             var path = Path.Combine(BaseDir, "Test0.cs");
             File.Delete(path);
 
@@ -31,7 +31,7 @@ namespace StyleChecker.Test.Cleaning.ByteOrderMark
         [TestMethod]
         public void Empty()
         {
-            var code = @"";
+            var code = "";
             var path = Path.Combine(BaseDir, "Test0.cs");
             File.WriteAllText(path, code, Encoding.ASCII);
 

--- a/StyleChecker/StyleChecker.Test/Cleaning/RedundantTypedArrayCreation/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Cleaning/RedundantTypedArrayCreation/AnalyzerTest.cs
@@ -14,7 +14,7 @@ namespace StyleChecker.Test.Cleaning.RedundantTypedArrayCreation
 
         [TestMethod]
         public void Empty()
-            => VerifyDiagnostic(@"", Atmosphere.Default);
+            => VerifyDiagnostic("", Atmosphere.Default);
 
         [TestMethod]
         public void Okay()
@@ -25,7 +25,7 @@ namespace StyleChecker.Test.Cleaning.RedundantTypedArrayCreation
         {
             var code = ReadText("Code");
             var fix = ReadText("CodeFix");
-            Result Expected(Belief b) => b.ToResult(
+            static Result Expected(Belief b) => b.ToResult(
                 Analyzer.DiagnosticId,
                 $"Remove '{b.Message}' to use  an implicitly-typed array "
                 + "creation.");

--- a/StyleChecker/StyleChecker.Test/Cleaning/UnusedUsing/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Cleaning/UnusedUsing/AnalyzerTest.cs
@@ -15,13 +15,13 @@ namespace StyleChecker.Test.Cleaning.UnusedUsing
 
         [TestMethod]
         public void Empty()
-            => VerifyDiagnostic(@"", Atmosphere.Default);
+            => VerifyDiagnostic("", Atmosphere.Default);
 
         [TestMethod]
         public void Code()
         {
             var code = ReadText("Code");
-            Result Expected(Belief b) => b.ToResult(
+            static Result Expected(Belief b) => b.ToResult(
                 Analyzer.DiagnosticId,
                 "The using directive is unused.");
 

--- a/StyleChecker/StyleChecker.Test/Cleaning/UnusedVariable/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Cleaning/UnusedVariable/AnalyzerTest.cs
@@ -17,7 +17,7 @@ namespace StyleChecker.Test.Cleaning.UnusedVariable
 
         [TestMethod]
         public void Empty()
-            => VerifyDiagnostic(@"", Atmosphere.Default);
+            => VerifyDiagnostic("", Atmosphere.Default);
 
         [TestMethod]
         public void Okay()

--- a/StyleChecker/StyleChecker.Test/Document/NoDocumentation/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Document/NoDocumentation/AnalyzerTest.cs
@@ -9,7 +9,7 @@ namespace StyleChecker.Test.Document.NoDocumentation
     [TestClass]
     public sealed class AnalyzerTest : DiagnosticVerifier
     {
-        private ImmutableArray<string> ignoreIds
+        private readonly ImmutableArray<string> ignoreIds
             = ImmutableArray.Create("CS1591");
 
         public AnalyzerTest()
@@ -19,7 +19,7 @@ namespace StyleChecker.Test.Document.NoDocumentation
 
         [TestMethod]
         public void Empty()
-            => VerifyDiagnostic(@"", Atmosphere.Default);
+            => VerifyDiagnostic("", Atmosphere.Default);
 
         [TestMethod]
         public void Okay()
@@ -49,7 +49,7 @@ namespace StyleChecker.Test.Document.NoDocumentation
         public void Code()
         {
             var code = ReadText("Code");
-            Result Expected(Belief b) => b.ToResult(
+            static Result Expected(Belief b) => b.ToResult(
                 Analyzer.DiagnosticId,
                 "Missing XML comment for publicly visible type or member "
                 + $"'{b.Message}'");

--- a/StyleChecker/StyleChecker.Test/Framework/Atmosphere.cs
+++ b/StyleChecker/StyleChecker.Test/Framework/Atmosphere.cs
@@ -48,12 +48,12 @@ namespace StyleChecker.Test.Framework
         /// represents the directory actually containing those files like
         /// <c>Test0.cs</c>.
         /// </remarks>
-        public string BasePath { get; private set; }
+        public string? BasePath { get; private set; }
 
         /// <summary>
         /// Gets the configuration XML text.
         /// </summary>
-        public string ConfigText { get; private set; }
+        public string? ConfigText { get; private set; }
 
         /// <summary>
         /// Gets all IDs of diagnostics to be ignored.
@@ -65,6 +65,9 @@ namespace StyleChecker.Test.Framework
         /// </summary>
         public bool ForceLocationValid { get; private set; }
 
+        /// <summary>
+        /// Gets the documentation mode.
+        /// </summary>
         public DocumentationMode DocumentationMode { get; private set; }
 
         /// <summary>
@@ -142,7 +145,7 @@ namespace StyleChecker.Test.Framework
 
         private Atmosphere With(Action<Atmosphere> update)
         {
-            var clone = MemberwiseClone() as Atmosphere;
+            var clone = (Atmosphere)MemberwiseClone();
             update(clone);
             return clone;
         }

--- a/StyleChecker/StyleChecker.Test/Framework/BeliefExtractor.cs
+++ b/StyleChecker/StyleChecker.Test/Framework/BeliefExtractor.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS8619
+
 namespace StyleChecker.Test.Framework
 {
     using System;
@@ -58,7 +60,7 @@ namespace StyleChecker.Test.Framework
                     prefix, StringComparison.Ordinal))
                 .ToArray();
 
-            int GetLine(SyntaxTrivia trivia)
+            static int GetLine(SyntaxTrivia trivia)
             {
                 return trivia.GetLocation()
                     .GetLineSpan()

--- a/StyleChecker/StyleChecker.Test/Framework/Beliefs.cs
+++ b/StyleChecker/StyleChecker.Test/Framework/Beliefs.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS8619
+
 namespace StyleChecker.Test.Framework
 {
     using System;
@@ -34,7 +36,7 @@ namespace StyleChecker.Test.Framework
             IEnumerable<string> excludeIds,
             Func<Belief, Result> toResult)
         {
-            Belief ToBelief(Diagnostic d)
+            static Belief ToBelief(Diagnostic d)
             {
                 var s = d.Location
                     .GetLineSpan()
@@ -43,6 +45,7 @@ namespace StyleChecker.Test.Framework
                 var column = s.Character + 1;
                 return new Belief(row, column, d.GetMessage());
             }
+
             var rawBeliefs = NewDiagnostics(encodedSource, excludeIds)
                 .Select(ToBelief)
                 .ToArray();
@@ -113,7 +116,7 @@ namespace StyleChecker.Test.Framework
                 }
             }
             var sum = 0;
-            var newArray = lines.ToArray();
+            string?[] newArray = lines.ToArray();
             var newList = new List<Belief>();
             foreach (var (row, list) in map)
             {
@@ -122,7 +125,7 @@ namespace StyleChecker.Test.Framework
                 newList.AddRange(list.Select(b => b.WithRow(b.Row - sum)));
                 sum += m;
             }
-            return (newArray.Where(s => !(s is null)), newList);
+            return (newArray.OfType<string>(), newList);
         }
     }
 }

--- a/StyleChecker/StyleChecker.Test/Framework/CodeFixVerifier.cs
+++ b/StyleChecker/StyleChecker.Test/Framework/CodeFixVerifier.cs
@@ -244,7 +244,7 @@ namespace StyleChecker.Test.Framework
         private static void Compare(
             DocumentId id, string actual, string expected)
         {
-            string Hex(string s)
+            static string Hex(string s)
             {
                 var all = s.Select(c => $"0x{Convert.ToInt32(c):X}");
                 return string.Join(',', all);

--- a/StyleChecker/StyleChecker.Test/Framework/DiagnosticVerifier.cs
+++ b/StyleChecker/StyleChecker.Test/Framework/DiagnosticVerifier.cs
@@ -326,6 +326,7 @@ namespace StyleChecker.Test.Framework
 
                 void AssertOne<T>(
                     string label, T expectedValue, T actualValue)
+                    where T : object
                 {
                     if (expectedValue.Equals(actualValue))
                     {
@@ -380,6 +381,7 @@ namespace StyleChecker.Test.Framework
             AssertFailIfFalse(
                 actualSpan.Path == expected.Path
                     || (!(actualSpan.Path is null)
+                        && !(expected.Path is null)
                         && actualSpan.Path.Contains("Test0.")
                         && expected.Path.Contains("Test.")),
                 () => $"Expected diagnostic to be in file '{expected.Path}' "

--- a/StyleChecker/StyleChecker.Test/Framework/Result.cs
+++ b/StyleChecker/StyleChecker.Test/Framework/Result.cs
@@ -62,7 +62,9 @@ namespace StyleChecker.Test.Framework
         /// <summary>
         /// Gets the path of the first location.
         /// </summary>
-        public string Path => Locations.Length > 0 ? Locations[0].Path : "";
+        public string Path => Locations.Length > 0
+            ? (Locations[0].Path ?? "")
+            : "";
 
         /// <summary>
         /// Gets the line number of the first location.

--- a/StyleChecker/StyleChecker.Test/Framework/ResultLocation.cs
+++ b/StyleChecker/StyleChecker.Test/Framework/ResultLocation.cs
@@ -17,7 +17,7 @@ namespace StyleChecker.Test.Framework
         /// <param name="path">The path of the source file.</param>
         /// <param name="line">The line number.</param>
         /// <param name="column">The column number.</param>
-        public ResultLocation(string path, int line, int column)
+        public ResultLocation(string? path, int line, int column)
         {
             if (line < -1)
             {
@@ -31,7 +31,7 @@ namespace StyleChecker.Test.Framework
                     nameof(column), "column must be >= -1");
             }
 
-            Path = path;
+            Path = path ?? "";
             Line = line;
             Column = column;
         }

--- a/StyleChecker/StyleChecker.Test/Naming/ThoughtlessName/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Naming/ThoughtlessName/AnalyzerTest.cs
@@ -16,7 +16,7 @@ namespace StyleChecker.Test.Naming.ThoughtlessName
 
         [TestMethod]
         public void Empty()
-            => VerifyDiagnostic(@"", Atmosphere.Default);
+            => VerifyDiagnostic("", Atmosphere.Default);
 
         [TestMethod]
         public void Okay()
@@ -26,7 +26,8 @@ namespace StyleChecker.Test.Naming.ThoughtlessName
         public void Code()
         {
             var code = ReadText("Code");
-            Result ToResult(
+
+            static Result ToResult(
                 Belief b,
                 string token,
                 string type,
@@ -34,14 +35,14 @@ namespace StyleChecker.Test.Naming.ThoughtlessName
                     Analyzer.DiagnosticId,
                     $"The name '{token}' is too easy: {reason(token, type)}");
 
-            string ToSymbol(string token)
+            static string ToSymbol(string token)
                 => token.StartsWith('@') ? token.Substring(1) : token;
 
-            string Arconym(string token, string type)
+            static string Arconym(string token, string type)
                 => $"'{ToSymbol(token)}' is probably an acronym of its type "
                     + $"name '{type}'";
 
-            string HungarianPrefix(string token, string type)
+            static string HungarianPrefix(string token, string type)
                 => "Hungarian notation is probably used for "
                     + $"'{ToSymbol(token)}', because the type name is "
                     + $"'{type}'";
@@ -70,7 +71,7 @@ namespace StyleChecker.Test.Naming.ThoughtlessName
             var atmosphere = Atmosphere.Default
                 .WithConfigText(configText);
 
-            Result Expected(Belief b)
+            static Result Expected(Belief b)
             {
                 return b.ToResult(
                     Analyzer.DiagnosticId,

--- a/StyleChecker/StyleChecker.Test/Naming/Underscore/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Naming/Underscore/AnalyzerTest.cs
@@ -14,7 +14,7 @@ namespace StyleChecker.Test.Naming.Underscore
 
         [TestMethod]
         public void Empty()
-            => VerifyDiagnostic(@"", Atmosphere.Default);
+            => VerifyDiagnostic("", Atmosphere.Default);
 
         [TestMethod]
         public void Okay()
@@ -25,7 +25,8 @@ namespace StyleChecker.Test.Naming.Underscore
         {
             var code = ReadText("Code");
             var fix = ReadText("CodeFix");
-            Result Expected(Belief b) => b.ToResult(
+
+            static Result Expected(Belief b) => b.ToResult(
                 Analyzer.DiagnosticId,
                 m => $"The name '{m}' includes a underscore.");
 

--- a/StyleChecker/StyleChecker.Test/Ordering/PostIncrement/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Ordering/PostIncrement/AnalyzerTest.cs
@@ -14,14 +14,15 @@ namespace StyleChecker.Test.Ordering.PostIncrement
 
         [TestMethod]
         public void Empty()
-            => VerifyDiagnostic(@"", Atmosphere.Default);
+            => VerifyDiagnostic("", Atmosphere.Default);
 
         [TestMethod]
         public void Code()
         {
             var code = ReadText("Code");
             var fix = ReadText("CodeFix");
-            Result Expected(Belief b) => b.ToResult(
+
+            static Result Expected(Belief b) => b.ToResult(
                 Analyzer.DiagnosticId,
                 m => $"The expression '{m}' must be replaced with the one "
                     + "using a pre-increment/decrement operator.");

--- a/StyleChecker/StyleChecker.Test/Refactoring/AssignmentToParameter/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/AssignmentToParameter/AnalyzerTest.cs
@@ -20,7 +20,7 @@ namespace StyleChecker.Test.Refactoring.AssignmentToParameter
         public void Code()
         {
             var code = ReadText("Code");
-            Result Expected(Belief b) => b.ToResult(
+            static Result Expected(Belief b) => b.ToResult(
                 Analyzer.DiagnosticId,
                 m => $"The assignment to the parameter '{m}' must be "
                     + "avoided.");

--- a/StyleChecker/StyleChecker.Test/Refactoring/DiscardingReturnValue/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/DiscardingReturnValue/AnalyzerTest.cs
@@ -40,7 +40,7 @@ namespace StyleChecker.Test.Refactoring.DiscardingReturnValue
             var configText = ReadText("MethodsConfig", "xml");
             var atmosphere = Atmosphere.Default
                 .WithConfigText(configText);
-            Result Expected(Belief b) => b.ToResult(
+            static Result Expected(Belief b) => b.ToResult(
                 Analyzer.DiagnosticId,
                 m => $"The return value of '{m}' must be used.");
 

--- a/StyleChecker/StyleChecker.Test/Refactoring/EmptyArrayCreation/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/EmptyArrayCreation/AnalyzerTest.cs
@@ -14,7 +14,7 @@ namespace StyleChecker.Test.Refactoring.EmptyArrayCreation
 
         [TestMethod]
         public void Empty()
-            => VerifyDiagnostic(@"", Atmosphere.Default);
+            => VerifyDiagnostic("", Atmosphere.Default);
 
         [TestMethod]
         public void Okay()
@@ -25,7 +25,7 @@ namespace StyleChecker.Test.Refactoring.EmptyArrayCreation
         {
             var code = ReadText("Code");
             var fix = ReadText("CodeFix");
-            Result Expected(Belief b) => b.ToResult(
+            static Result Expected(Belief b) => b.ToResult(
                 Analyzer.DiagnosticId,
                 $"Use 'System.Array.Empty<{b.Message}>()' instead of an empty "
                 + "array creation.");

--- a/StyleChecker/StyleChecker.Test/Refactoring/EqualsNull/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/EqualsNull/AnalyzerTest.cs
@@ -22,7 +22,7 @@ namespace StyleChecker.Test.Refactoring.EqualsNull
         {
             var code = ReadText("Code");
             var fix = ReadText("CodeFix");
-            Result Expected(Belief b)
+            static Result Expected(Belief b)
             {
                 var token = b.Message;
                 return b.ToResult(

--- a/StyleChecker/StyleChecker.Test/Refactoring/IneffectiveReadByte/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/IneffectiveReadByte/AnalyzerTest.cs
@@ -21,7 +21,7 @@ namespace StyleChecker.Test.Refactoring.IneffectiveReadByte
         {
             var code = ReadText("Code");
             var fix = ReadText("CodeFix");
-            Result Expected(Belief b)
+            static Result Expected(Belief b)
             {
                 var array = b.Message.Split(' ');
                 var name = array[0];

--- a/StyleChecker/StyleChecker.Test/Refactoring/IsNull/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/IsNull/AnalyzerTest.cs
@@ -22,7 +22,7 @@ namespace StyleChecker.Test.Refactoring.IsNull
         {
             var code = ReadText("Code");
             var fix = ReadText("CodeFix");
-            Result Expected(Belief b)
+            static Result Expected(Belief b)
             {
                 var token = b.Message;
                 return b.ToResult(

--- a/StyleChecker/StyleChecker.Test/Refactoring/NotDesignedForExtension/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/NotDesignedForExtension/AnalyzerTest.cs
@@ -21,7 +21,7 @@ namespace StyleChecker.Test.Refactoring.NotDesignedForExtenstion
         public void Code()
         {
             var code = ReadText("Code");
-            Result Expected(Belief b)
+            static Result Expected(Belief b)
             {
                 var m = b.Message.Split(",");
                 var map = new Dictionary<string, (string, string)>
@@ -43,7 +43,7 @@ namespace StyleChecker.Test.Refactoring.NotDesignedForExtenstion
         public void Example()
         {
             var code = ReadText("Example");
-            Result Expected(Belief b)
+            static Result Expected(Belief b)
             {
                 var m = b.Message.Split(",");
                 var map = new Dictionary<string, (string, string)>

--- a/StyleChecker/StyleChecker.Test/Refactoring/StaticGenericClass/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/StaticGenericClass/AnalyzerTest.cs
@@ -14,7 +14,7 @@ namespace StyleChecker.Test.Refactoring.StaticGenericClass
 
         [TestMethod]
         public void Empty()
-            => VerifyDiagnostic(@"", Atmosphere.Default);
+            => VerifyDiagnostic("", Atmosphere.Default);
 
         [TestMethod]
         public void Okay()
@@ -25,7 +25,7 @@ namespace StyleChecker.Test.Refactoring.StaticGenericClass
         {
             var code = ReadText("Code");
             var fix = ReadText("CodeFix");
-            Result Expected(Belief b) => b.ToResult(
+            static Result Expected(Belief b) => b.ToResult(
                 Analyzer.DiagnosticId,
                 m => "Type parameters of the static class "
                     + $"{m} must be moved to its methods.");

--- a/StyleChecker/StyleChecker.Test/Refactoring/UnnecessaryUsing/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/UnnecessaryUsing/AnalyzerTest.cs
@@ -17,7 +17,7 @@ namespace StyleChecker.Test.Refactoring.UnnecessaryUsing
         {
             var code = ReadText("Code");
             var fix = ReadText("CodeFix");
-            Result Expected(Belief b) => b.ToResult(
+            static Result Expected(Belief b) => b.ToResult(
                 Analyzer.DiagnosticId,
                 m => $"The using statement is not necessary for '{m}'.");
 

--- a/StyleChecker/StyleChecker.Test/Settings/InvalidConfig/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Settings/InvalidConfig/AnalyzerTest.cs
@@ -16,7 +16,7 @@ namespace StyleChecker.Test.Settings.InvalidConfig
 
         [TestMethod]
         public void Empty()
-            => VerifyDiagnostic(@"", Atmosphere.Default);
+            => VerifyDiagnostic("", Atmosphere.Default);
 
         [TestMethod]
         public void Okay()

--- a/StyleChecker/StyleChecker.Test/Size/LongLine/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Size/LongLine/AnalyzerTest.cs
@@ -14,7 +14,7 @@ namespace StyleChecker.Test.Size.LongLine
 
         [TestMethod]
         public void Empty()
-            => VerifyDiagnostic(@"", Atmosphere.Default);
+            => VerifyDiagnostic("", Atmosphere.Default);
 
         [TestMethod]
         public void Okay()

--- a/StyleChecker/StyleChecker.Test/Spacing/NoSingleSpaceAfterTripleSlash/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Spacing/NoSingleSpaceAfterTripleSlash/AnalyzerTest.cs
@@ -14,14 +14,14 @@ namespace StyleChecker.Test.Spacing.NoSingleSpaceAfterTripleSlash
 
         [TestMethod]
         public void Empty()
-            => VerifyDiagnostic(@"", Atmosphere.Default);
+            => VerifyDiagnostic("", Atmosphere.Default);
 
         [TestMethod]
         public void Code()
         {
             var code = ReadText("Code");
             var fix = ReadText("CodeFix");
-            Result Expected(Belief b) => b.ToResult(
+            static Result Expected(Belief b) => b.ToResult(
                 Analyzer.DiagnosticId,
                 m => $"A single white space is needed after '///'");
 

--- a/StyleChecker/StyleChecker.Test/Spacing/NoSpaceAfterSemicolon/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Spacing/NoSpaceAfterSemicolon/AnalyzerTest.cs
@@ -14,14 +14,14 @@ namespace StyleChecker.Test.Spacing.NoSpaceAfterSemicolon
 
         [TestMethod]
         public void Empty()
-            => VerifyDiagnostic(@"", Atmosphere.Default);
+            => VerifyDiagnostic("", Atmosphere.Default);
 
         [TestMethod]
         public void Code()
         {
             var code = ReadText("Code");
             var fix = ReadText("CodeFix");
-            Result Expected(Belief b) => b.ToResult(
+            static Result Expected(Belief b) => b.ToResult(
                 Analyzer.DiagnosticId,
                 m => $"A white space is needed after '{m}'");
 

--- a/StyleChecker/StyleChecker.Test/Spacing/SpaceBeforeSemicolon/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Spacing/SpaceBeforeSemicolon/AnalyzerTest.cs
@@ -14,14 +14,14 @@ namespace StyleChecker.Test.Spacing.SpaceBeforeSemicolon
 
         [TestMethod]
         public void Empty()
-            => VerifyDiagnostic(@"", Atmosphere.Default);
+            => VerifyDiagnostic("", Atmosphere.Default);
 
         [TestMethod]
         public void Code()
         {
             var code = ReadText("Code");
             var fix = ReadText("CodeFix");
-            Result Expected(Belief b) => b.ToResult(
+            static Result Expected(Belief b) => b.ToResult(
                 Analyzer.DiagnosticId,
                 m => $"A white space is not needed before '{m}'");
 

--- a/StyleChecker/StyleChecker.Test/StyleChecker.Test.csproj
+++ b/StyleChecker/StyleChecker.Test/StyleChecker.Test.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/StyleChecker/StyleChecker/AbstractAnalyzer.cs
+++ b/StyleChecker/StyleChecker/AbstractAnalyzer.cs
@@ -1,0 +1,27 @@
+namespace StyleChecker
+{
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    /// <summary>
+    /// The abstraction of analyzers.
+    /// </summary>
+    public abstract class AbstractAnalyzer : DiagnosticAnalyzer
+    {
+        /// <inheritdoc/>
+        public sealed override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(
+                GeneratedCodeAnalysisFlags.None);
+            Register(context);
+        }
+
+        /// <summary>
+        /// Resgisters actions with the specified <see
+        /// cref="AnalysisContext"/>.
+        /// </summary>
+        /// <param name="context">
+        /// The analysis context.
+        /// </param>
+        private protected abstract void Register(AnalysisContext context);
+    }
+}

--- a/StyleChecker/StyleChecker/Cleaning/ByteOrderMark/Globs.cs
+++ b/StyleChecker/StyleChecker/Cleaning/ByteOrderMark/Globs.cs
@@ -47,12 +47,10 @@ namespace StyleChecker.Cleaning.ByteOrderMark
         /// </returns>
         public static string ToPattern(IEnumerable<string> all)
         {
-            return string.Join(
-                string.Empty,
-                all.Select(ToPattern)
-                    .Separate("|")
-                    .Prepend("^(")
-                    .Append(")$"));
+            return string.Concat(all.Select(ToPattern)
+                .Separate("|")
+                .Prepend("^(")
+                .Append(")$"));
         }
 
         private static string ToPattern(string rawInput)

--- a/StyleChecker/StyleChecker/Cleaning/UnusedUsing/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Cleaning/UnusedUsing/Analyzer.cs
@@ -10,7 +10,7 @@ namespace StyleChecker.Cleaning.UnusedUsing
     /// UnusedUsing analyzer.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class Analyzer : DiagnosticAnalyzer
+    public sealed class Analyzer : AbstractAnalyzer
     {
         /// <summary>
         /// The ID of this analyzer.
@@ -25,10 +25,8 @@ namespace StyleChecker.Cleaning.UnusedUsing
             SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+        private protected override void Register(AnalysisContext context)
         {
-            context.ConfigureGeneratedCodeAnalysis(
-                GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
             context.RegisterSemanticModelAction(AnalyzeModel);
         }

--- a/StyleChecker/StyleChecker/Cleaning/UnusedVariable/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Cleaning/UnusedVariable/Analyzer.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS8619
+
 namespace StyleChecker.Cleaning.UnusedVariable
 {
     using System;
@@ -18,7 +20,7 @@ namespace StyleChecker.Cleaning.UnusedVariable
     /// UnusedVariable analyzer.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class Analyzer : DiagnosticAnalyzer
+    public sealed class Analyzer : AbstractAnalyzer
     {
         /// <summary>
         /// The ID of this analyzer.
@@ -33,10 +35,8 @@ namespace StyleChecker.Cleaning.UnusedVariable
             SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+        private protected override void Register(AnalysisContext context)
         {
-            context.ConfigureGeneratedCodeAnalysis(
-                GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
             context.RegisterSemanticModelAction(AnalyzeModel);
         }
@@ -130,13 +130,13 @@ namespace StyleChecker.Cleaning.UnusedVariable
                 return;
             }
 
-            bool IsEmptyBody(InvocableBaseNodePod pod)
+            static bool IsEmptyBody(InvocableBaseNodePod pod)
             {
                 return (pod.Body is null || !pod.Body.ChildNodes().Any())
                     && pod.ExpressionBody is null;
             }
 
-            bool IsMarkedAsUnused(AttributeData d)
+            static bool IsMarkedAsUnused(AttributeData d)
                 => d.AttributeClass.ToString()
                     == typeof(UnusedAttribute).FullName;
 

--- a/StyleChecker/StyleChecker/Config/ByteOrderMarkConfig.cs
+++ b/StyleChecker/StyleChecker/Config/ByteOrderMarkConfig.cs
@@ -18,7 +18,7 @@ namespace StyleChecker.Config
             Multiple.Of<File>());
 
         [field: ForAttribute("maxDepth")]
-        private BindEvent<string> MaxDepthEvent { get; }
+        private BindEvent<string>? MaxDepthEvent { get; }
 
         [field: ForChild]
         private IEnumerable<File> Files { get; } = Enumerable.Empty<File>();
@@ -40,7 +40,9 @@ namespace StyleChecker.Config
         /// <returns>
         /// All the glob patterns.
         /// </returns>
-        public IEnumerable<string> GetGlobs() => Files.Select(e => e.Glob);
+        public IEnumerable<string> GetGlobs()
+            => Files.Select(e => e.Glob)
+                .OfType<string>();
 
         /// <inheritdoc/>
         public override IEnumerable<(int, int, string)> Validate()
@@ -61,7 +63,7 @@ namespace StyleChecker.Config
             /// start with a BOM.
             /// </summary>
             [field: ForAttribute("glob")]
-            public string Glob { get; }
+            public string? Glob { get; }
         }
     }
 }

--- a/StyleChecker/StyleChecker/Config/DiscardingReturnValueConfig.cs
+++ b/StyleChecker/StyleChecker/Config/DiscardingReturnValueConfig.cs
@@ -29,7 +29,8 @@ namespace StyleChecker.Config
         /// </returns>
         public IEnumerable<string> GetMethodSignatures()
         {
-            return MethodElements.Select(e => e.Id);
+            return MethodElements.Select(e => e.Id)
+                .OfType<string>();
         }
 
         /// <inheritdoc/>
@@ -46,7 +47,7 @@ namespace StyleChecker.Config
             /// Gets the signature of the method.
             /// </summary>
             [field: ForAttribute("id")]
-            public string Id { get; }
+            public string? Id { get; }
         }
     }
 }

--- a/StyleChecker/StyleChecker/Config/LongLineConfig.cs
+++ b/StyleChecker/StyleChecker/Config/LongLineConfig.cs
@@ -12,7 +12,7 @@ namespace StyleChecker.Config
         private const int DefaultMaxLineLength = 80;
 
         [field: ForAttribute("maxLineLength")]
-        private BindEvent<string> MaxLineLengthEvent { get; }
+        private BindEvent<string>? MaxLineLengthEvent { get; }
 
         /// <inheritdoc/>
         public override IEnumerable<(int, int, string)> Validate()

--- a/StyleChecker/StyleChecker/Config/NoDocumentationConfig.cs
+++ b/StyleChecker/StyleChecker/Config/NoDocumentationConfig.cs
@@ -29,7 +29,8 @@ namespace StyleChecker.Config
         public IEnumerable<string> GetInclusiveAttributes()
         {
             return IgnoreElements.Where(e => e.IsInclusive())
-                .Select(e => e.With);
+                .Select(e => e.With)
+                .OfType<string>();
         }
 
         /// <summary>
@@ -42,7 +43,8 @@ namespace StyleChecker.Config
         public IEnumerable<string> GetAttributes()
         {
             return IgnoreElements.Where(e => !e.IsInclusive())
-                .Select(e => e.With);
+                .Select(e => e.With)
+                .OfType<string>();
         }
 
         /// <inheritdoc/>
@@ -62,14 +64,14 @@ namespace StyleChecker.Config
             /// Gets the attribute class.
             /// </summary>
             [field: ForAttribute("with")]
-            public string With { get; }
+            public string? With { get; }
 
             /// <summary>
             /// Gets whether the element only is ignored or all the elements it
             /// contains are ignored.
             /// </summary>
             [field: ForAttribute("inclusive")]
-            public BindEvent<string> InclusiveEvent { get; }
+            public BindEvent<string>? InclusiveEvent { get; }
 
             /// <inheritdoc/>
             public IEnumerable<(int, int, string)> Validate()

--- a/StyleChecker/StyleChecker/Config/ParseKit.cs
+++ b/StyleChecker/StyleChecker/Config/ParseKit.cs
@@ -43,7 +43,7 @@ namespace StyleChecker.Config
         /// otherwise.
         /// </returns>
         public static bool ToBooleanValue(
-            BindEvent<string> ev, bool defaultValue)
+            BindEvent<string>? ev, bool defaultValue)
         {
             return (ev is null)
                 ? defaultValue
@@ -70,7 +70,7 @@ namespace StyleChecker.Config
         /// otherwise.
         /// </returns>
         public static int ToIntValue(
-            BindEvent<string> ev,
+            BindEvent<string>? ev,
             int defaultValue,
             Func<int, bool> isValidValue)
         {
@@ -100,7 +100,7 @@ namespace StyleChecker.Config
         /// the line number, the column number and the error message.
         /// </returns>
         public static IEnumerable<(int, int, string)> ValidateBoolean(
-            BindEvent<string> ev,
+            BindEvent<string>? ev,
             string invalidBooleanValueError)
         {
             if (ev is null)
@@ -138,7 +138,7 @@ namespace StyleChecker.Config
         /// the line number, the column number and the error message.
         /// </returns>
         public static IEnumerable<(int, int, string)> ValidateInt(
-            BindEvent<string> ev,
+            BindEvent<string>? ev,
             Func<int, bool> isValidValue,
             string invalidIntegerValueError,
             string invalidValueRangeError)

--- a/StyleChecker/StyleChecker/Config/ThoughtlessNameConfig.cs
+++ b/StyleChecker/StyleChecker/Config/ThoughtlessNameConfig.cs
@@ -28,7 +28,8 @@ namespace StyleChecker.Config
         /// </returns>
         public IEnumerable<string> GetDisallowedIdentifiers()
         {
-            return DisallowElements.Select(e => e.Id);
+            return DisallowElements.Select(e => e.Id)
+                .OfType<string>();
         }
 
         /// <inheritdoc/>
@@ -45,7 +46,7 @@ namespace StyleChecker.Config
             /// Gets the identifier to be disallowed.
             /// </summary>
             [field: ForAttribute("id")]
-            public string Id { get; }
+            public string? Id { get; }
         }
     }
 }

--- a/StyleChecker/StyleChecker/EmbeddedResources.cs
+++ b/StyleChecker/StyleChecker/EmbeddedResources.cs
@@ -23,20 +23,16 @@ namespace StyleChecker
         public static string GetText(string folder, string filename)
         {
             var name = $"StyleChecker.{folder}.{filename}";
-            using (var stream = typeof(EmbeddedResources).GetTypeInfo()
+            using var stream = typeof(EmbeddedResources).GetTypeInfo()
                 .Assembly
-                .GetManifestResourceStream(name))
-            {
-                return GetString(stream);
-            }
+                .GetManifestResourceStream(name);
+            return GetString(stream);
         }
 
         private static string GetString(Stream stream)
         {
-            using (var reader = new StreamReader(stream))
-            {
-                return reader.ReadToEnd();
-            }
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
         }
     }
 }

--- a/StyleChecker/StyleChecker/Invocables/InvocableBaseNodePod.cs
+++ b/StyleChecker/StyleChecker/Invocables/InvocableBaseNodePod.cs
@@ -29,6 +29,10 @@ namespace StyleChecker.Invocables
             WithArrowExpressionClauseSyntax
                 = With<ArrowExpressionClauseSyntax>(node.WithExpressionBody);
             WithSemicolonToken = With<SyntaxToken>(node.WithSemicolonToken);
+
+            WithNoArrowExpressionClauseSyntax
+                = () => new InvocableBaseNodePod(
+                    node.WithExpressionBody(null));
         }
 
         private InvocableBaseNodePod(LocalFunctionStatementSyntax node)
@@ -49,6 +53,10 @@ namespace StyleChecker.Invocables
             WithArrowExpressionClauseSyntax
                 = With<ArrowExpressionClauseSyntax>(node.WithExpressionBody);
             WithSemicolonToken = With<SyntaxToken>(node.WithSemicolonToken);
+
+            WithNoArrowExpressionClauseSyntax
+                = () => new InvocableBaseNodePod(
+                    node.WithExpressionBody(null));
         }
 
         /// <inheritdoc/>
@@ -78,6 +86,9 @@ namespace StyleChecker.Invocables
         private Func<SyntaxToken, InvocableBaseNodePod>
             WithSemicolonToken { get; }
 
+        private Func<InvocableBaseNodePod>
+            WithNoArrowExpressionClauseSyntax { get; }
+
         /// <summary>
         /// Gets a new <see cref="InvocableBaseNodePod"/> object wrappings the
         /// specified <see cref="SyntaxNode"/> node.
@@ -89,7 +100,7 @@ namespace StyleChecker.Invocables
         /// <returns>
         /// The new <see cref="InvocableBaseNodePod"/> object.
         /// </returns>
-        public static InvocableBaseNodePod Of(SyntaxNode node)
+        public static InvocableBaseNodePod? Of(SyntaxNode node)
         {
             return node is LocalFunctionStatementSyntax localFunction
                 ? new InvocableBaseNodePod(localFunction)
@@ -113,5 +124,9 @@ namespace StyleChecker.Invocables
         /// <inheritdoc/>
         public InvocableBaseNodePod With(SyntaxToken node)
             => WithSemicolonToken(node);
+
+        /// <inheritdoc/>
+        public InvocableBaseNodePod WithoutArrowExpressionClauseSyntax()
+            => WithNoArrowExpressionClauseSyntax();
     }
 }

--- a/StyleChecker/StyleChecker/Invocables/InvocableBasePrototype.cs
+++ b/StyleChecker/StyleChecker/Invocables/InvocableBasePrototype.cs
@@ -60,5 +60,14 @@ namespace StyleChecker.Invocables
         /// The new <c>T</c> object.
         /// </returns>
         T With(SyntaxToken node);
+
+        /// <summary>
+        /// Gets a new <c>T</c> object without the <see
+        /// cref="ArrowExpressionClauseSyntax"/> object.
+        /// </summary>
+        /// <returns>
+        /// The new <c>T</c> object.
+        /// </returns>
+        T WithoutArrowExpressionClauseSyntax();
     }
 }

--- a/StyleChecker/StyleChecker/Invocables/InvocableNodePod.cs
+++ b/StyleChecker/StyleChecker/Invocables/InvocableNodePod.cs
@@ -33,6 +33,9 @@ namespace StyleChecker.Invocables
             WithSemicolonToken = With<SyntaxToken>(node.WithSemicolonToken);
             WithTypeParameterListSyntax
                 = With<TypeParameterListSyntax>(node.WithTypeParameterList);
+
+            WithNoArrowExpressionClauseSyntax
+                = () => new InvocableNodePod(node.WithExpressionBody(null));
         }
 
         private InvocableNodePod(LocalFunctionStatementSyntax node)
@@ -57,6 +60,9 @@ namespace StyleChecker.Invocables
             WithSemicolonToken = With<SyntaxToken>(node.WithSemicolonToken);
             WithTypeParameterListSyntax
                 = With<TypeParameterListSyntax>(node.WithTypeParameterList);
+
+            WithNoArrowExpressionClauseSyntax
+                = () => new InvocableNodePod(node.WithExpressionBody(null));
         }
 
         /// <inheritdoc/>
@@ -95,6 +101,9 @@ namespace StyleChecker.Invocables
         private Func<TypeParameterListSyntax, InvocableNodePod>
             WithTypeParameterListSyntax { get; }
 
+        private Func<InvocableNodePod>
+            WithNoArrowExpressionClauseSyntax { get; }
+
         /// <summary>
         /// Gets a new <see cref="InvocableNodePod"/> object wrappings the
         /// specified <see cref="SyntaxNode"/> node.
@@ -106,7 +115,7 @@ namespace StyleChecker.Invocables
         /// <returns>
         /// The new <see cref="InvocableNodePod"/> object.
         /// </returns>
-        public static InvocableNodePod Of(SyntaxNode node)
+        public static InvocableNodePod? Of(SyntaxNode node)
         {
             return node is LocalFunctionStatementSyntax localFunction
                 ? new InvocableNodePod(localFunction)
@@ -134,5 +143,9 @@ namespace StyleChecker.Invocables
         /// <inheritdoc/>
         public InvocableNodePod With(TypeParameterListSyntax node)
             => WithTypeParameterListSyntax(node);
+
+        /// <inheritdoc/>
+        public InvocableNodePod WithoutArrowExpressionClauseSyntax()
+            => WithNoArrowExpressionClauseSyntax();
     }
 }

--- a/StyleChecker/StyleChecker/Naming/SingleTypeParameter/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Naming/SingleTypeParameter/Analyzer.cs
@@ -12,7 +12,7 @@ namespace StyleChecker.Naming.SingleTypeParameter
     /// SingleTypeParameter analyzer.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class Analyzer : DiagnosticAnalyzer
+    public sealed class Analyzer : AbstractAnalyzer
     {
         /// <summary>
         /// The ID of this analyzer.
@@ -27,10 +27,8 @@ namespace StyleChecker.Naming.SingleTypeParameter
             SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+        private protected override void Register(AnalysisContext context)
         {
-            context.ConfigureGeneratedCodeAnalysis(
-                GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
             context.RegisterSyntaxTreeAction(AnalyzeSyntaxTree);
         }

--- a/StyleChecker/StyleChecker/Naming/Underscore/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Naming/Underscore/Analyzer.cs
@@ -11,7 +11,7 @@ namespace StyleChecker.Naming.Underscore
     /// Underscore analyzer.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class Analyzer : DiagnosticAnalyzer
+    public sealed class Analyzer : AbstractAnalyzer
     {
         /// <summary>
         /// The ID of this analyzer.
@@ -26,10 +26,8 @@ namespace StyleChecker.Naming.Underscore
             SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+        private protected override void Register(AnalysisContext context)
         {
-            context.ConfigureGeneratedCodeAnalysis(
-                GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
             context.RegisterSyntaxTreeAction(AnalyzeSyntaxTree);
         }
@@ -54,8 +52,9 @@ namespace StyleChecker.Naming.Underscore
             var root = context.Tree.GetCompilationUnitRoot(
                 context.CancellationToken);
 
-            bool ContainsUndersore(SyntaxToken t)
+            static bool ContainsUndersore(SyntaxToken t)
                 => t.Text.IndexOf('_') != -1;
+
             var all = LocalVariables.DeclarationTokens(root)
                 .Concat(LocalVariables.OutVariableTokens(root))
                 .Concat(LocalVariables.PatternMatchingTokens(root))

--- a/StyleChecker/StyleChecker/Ordering/PostIncrement/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Ordering/PostIncrement/Analyzer.cs
@@ -12,7 +12,7 @@ namespace StyleChecker.Ordering.PostIncrement
     /// PostIncrement analyzer.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class Analyzer : DiagnosticAnalyzer
+    public sealed class Analyzer : AbstractAnalyzer
     {
         /// <summary>
         /// The ID of this analyzer.
@@ -27,10 +27,8 @@ namespace StyleChecker.Ordering.PostIncrement
             SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+        private protected override void Register(AnalysisContext context)
         {
-            context.ConfigureGeneratedCodeAnalysis(
-                GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
             context.RegisterSyntaxTreeAction(AnalyzeSyntaxTree);
         }
@@ -52,13 +50,14 @@ namespace StyleChecker.Ordering.PostIncrement
         private static SyntaxNode[] FindTargetNodes(
             CompilationUnitSyntax root)
         {
-            bool Matches(SyntaxNode n)
+            static bool Matches(SyntaxNode n)
             {
                 return n.IsKindOneOf(
                     SyntaxKind.PostIncrementExpression,
                     SyntaxKind.PostDecrementExpression);
             }
-            bool MatchesParent(SyntaxNode n)
+
+            static bool MatchesParent(SyntaxNode n)
             {
                 var p = n.Parent;
                 return !(p is null)
@@ -66,6 +65,7 @@ namespace StyleChecker.Ordering.PostIncrement
                         SyntaxKind.ExpressionStatement,
                         SyntaxKind.ForStatement);
             }
+
             return root.DescendantNodes()
                 .Where(n => Matches(n) && MatchesParent(n))
                 .ToArray();

--- a/StyleChecker/StyleChecker/Refactoring/AssignmentToParameter/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Refactoring/AssignmentToParameter/Analyzer.cs
@@ -13,7 +13,7 @@ namespace StyleChecker.Refactoring.AssignmentToParameter
     /// AssignmentToParameter analyzer.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class Analyzer : DiagnosticAnalyzer
+    public sealed class Analyzer : AbstractAnalyzer
     {
         /// <summary>
         /// The ID of this analyzer.
@@ -28,10 +28,8 @@ namespace StyleChecker.Refactoring.AssignmentToParameter
             SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+        private protected override void Register(AnalysisContext context)
         {
-            context.ConfigureGeneratedCodeAnalysis(
-                GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
             context.RegisterSemanticModelAction(AnalyzeModel);
         }
@@ -53,7 +51,7 @@ namespace StyleChecker.Refactoring.AssignmentToParameter
         private static void AnalyzeModel(
             SemanticModelAnalysisContext context)
         {
-            bool IsRefOrOut(RefKind kind)
+            static bool IsRefOrOut(RefKind kind)
                 => kind == RefKind.Out || kind == RefKind.Ref;
 
             var cancellationToken = context.CancellationToken;

--- a/StyleChecker/StyleChecker/Refactoring/EmptyArrayCreation/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Refactoring/EmptyArrayCreation/Analyzer.cs
@@ -14,7 +14,7 @@ namespace StyleChecker.Refactoring.EmptyArrayCreation
     /// EmptyArrayCreation analyzer.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class Analyzer : DiagnosticAnalyzer
+    public sealed class Analyzer : AbstractAnalyzer
     {
         /// <summary>
         /// The ID of this analyzer.
@@ -29,10 +29,8 @@ namespace StyleChecker.Refactoring.EmptyArrayCreation
             SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+        private protected override void Register(AnalysisContext context)
         {
-            context.ConfigureGeneratedCodeAnalysis(
-                GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
             context.RegisterSemanticModelAction(AnalyzeModel);
         }
@@ -54,7 +52,7 @@ namespace StyleChecker.Refactoring.EmptyArrayCreation
         private static void AnalyzeModel(
             SemanticModelAnalysisContext context)
         {
-            bool IsZeroSize(IArrayCreationOperation o)
+            static bool IsZeroSize(IArrayCreationOperation o)
             {
                 var size = o.DimensionSizes[0].ConstantValue;
                 return o.Initializer is null
@@ -63,7 +61,7 @@ namespace StyleChecker.Refactoring.EmptyArrayCreation
                     && intValue == 0;
             }
 
-            bool NoInitializer(IArrayCreationOperation o)
+            static bool NoInitializer(IArrayCreationOperation o)
             {
                 return !(o.Initializer is null)
                     && !o.Initializer.ElementValues.Any();

--- a/StyleChecker/StyleChecker/Refactoring/EqualsNull/CodeFixer.cs
+++ b/StyleChecker/StyleChecker/Refactoring/EqualsNull/CodeFixer.cs
@@ -32,7 +32,7 @@ namespace StyleChecker.Refactoring.EqualsNull
         public override async Task RegisterCodeFixesAsync(
             CodeFixContext context)
         {
-            string FixTitle(string key)
+            static string FixTitle(string key)
             {
                 var localize = Localizers.Of<R>(R.ResourceManager);
                 return localize(key).ToString(CultureInfo.CurrentCulture);

--- a/StyleChecker/StyleChecker/Refactoring/IneffectiveReadByte/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Refactoring/IneffectiveReadByte/Analyzer.cs
@@ -15,7 +15,7 @@ namespace StyleChecker.Refactoring.IneffectiveReadByte
     /// IneffectiveReadByte analyzer.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class Analyzer : DiagnosticAnalyzer
+    public sealed class Analyzer : AbstractAnalyzer
     {
         /// <summary>
         /// The ID of this analyzer.
@@ -30,10 +30,8 @@ namespace StyleChecker.Refactoring.IneffectiveReadByte
             SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+        private protected override void Register(AnalysisContext context)
         {
-            context.ConfigureGeneratedCodeAnalysis(
-                GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
             context.RegisterSemanticModelAction(AnalyzeModel);
         }

--- a/StyleChecker/StyleChecker/Refactoring/IneffectiveReadByte/CodeFixer.cs
+++ b/StyleChecker/StyleChecker/Refactoring/IneffectiveReadByte/CodeFixer.cs
@@ -70,7 +70,7 @@ namespace StyleChecker.Refactoring.IneffectiveReadByte
                 .ConfigureAwait(false);
             var formatAnnotation = Formatter.Annotation;
 
-            string GetFixTemplate() => EmbeddedResources.GetText(
+            static string GetFixTemplate() => EmbeddedResources.GetText(
                 "Refactoring.IneffectiveReadByte", "FixTemplate.txt");
 
             var statement = Texts.Substitute(GetFixTemplate(), getValue);

--- a/StyleChecker/StyleChecker/Refactoring/IneffectiveReadByte/ExpressionStatements.cs
+++ b/StyleChecker/StyleChecker/Refactoring/IneffectiveReadByte/ExpressionStatements.cs
@@ -30,7 +30,7 @@ namespace StyleChecker.Refactoring.IneffectiveReadByte
         /// of the <c>array</c> is <paramref name="arrayType"/>, <c>null</c>
         /// otherwise.
         /// </returns>
-        public static ArrayAccess AccessArrayElement(
+        public static ArrayAccess? AccessArrayElement(
             SemanticModel model,
             SyntaxNode node,
             string arrayType)
@@ -96,7 +96,7 @@ namespace StyleChecker.Refactoring.IneffectiveReadByte
         /// method name is the specified <paramref name="memberName"/>,
         /// <c>null</c> otherwise.
         /// </returns>
-        public static ISymbol InvocationWithNoArgument(
+        public static ISymbol? InvocationWithNoArgument(
             SemanticModel model,
             SyntaxNode node,
             string instanceType,
@@ -130,7 +130,7 @@ namespace StyleChecker.Refactoring.IneffectiveReadByte
                 : symbol;
         }
 
-        private static ISymbol GetSymbolIfWhoseTypeIs(
+        private static ISymbol? GetSymbolIfWhoseTypeIs(
             SemanticModel model,
             SyntaxToken token,
             string instanceType)
@@ -151,7 +151,7 @@ namespace StyleChecker.Refactoring.IneffectiveReadByte
             return (instanceType != typeFullName) ? null : symbol;
         }
 
-        private static ITypeSymbol GetType(ISymbol symbol)
+        private static ITypeSymbol? GetType(ISymbol symbol)
         {
             if (symbol is ILocalSymbol localSymbol)
             {
@@ -170,15 +170,13 @@ namespace StyleChecker.Refactoring.IneffectiveReadByte
                 var getMethod = propertySymbol.GetMethod;
                 var reference = getMethod.DeclaringSyntaxReferences
                     .FirstOrDefault();
-                if (reference is null)
-                {
-                    return null;
-                }
-                var node = reference.GetSyntax() as AccessorDeclarationSyntax;
-                return (node is null
-                    || !(node.Body is null)
-                    || !(node.ExpressionBody is null))
-                    ? null : propertySymbol.Type;
+                return (reference is null
+                        || !(reference.GetSyntax()
+                            is AccessorDeclarationSyntax node)
+                        || !(node.Body is null)
+                        || !(node.ExpressionBody is null))
+                    ? null
+                    : propertySymbol.Type;
             }
             return null;
         }

--- a/StyleChecker/StyleChecker/Refactoring/IneffectiveReadByte/ForStatements.cs
+++ b/StyleChecker/StyleChecker/Refactoring/IneffectiveReadByte/ForStatements.cs
@@ -26,7 +26,7 @@ namespace StyleChecker.Refactoring.IneffectiveReadByte
         /// name="node"/> is a <c>for</c> statement and the range of the loop
         /// index is constant, <c>null</c> otherwise.
         /// </returns>
-        public static LoopIndexRange GetLoopIndexRange(
+        public static LoopIndexRange? GetLoopIndexRange(
             SemanticModel model, SyntaxNode node)
         {
             if (!(node is ForStatementSyntax forNode))

--- a/StyleChecker/StyleChecker/Refactoring/IsNull/CodeFixer.cs
+++ b/StyleChecker/StyleChecker/Refactoring/IsNull/CodeFixer.cs
@@ -34,7 +34,7 @@ namespace StyleChecker.Refactoring.IsNull
         public override async Task RegisterCodeFixesAsync(
             CodeFixContext context)
         {
-            string FixTitle(string key)
+            static string FixTitle(string key)
             {
                 var localize = Localizers.Of<R>(R.ResourceManager);
                 return localize(key).ToString(CultureInfo.CurrentCulture);

--- a/StyleChecker/StyleChecker/Refactoring/NotDesignedForExtension/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Refactoring/NotDesignedForExtension/Analyzer.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS8619
+
 namespace StyleChecker.Refactoring.NotDesignedForExtension
 {
     using System.Collections.Immutable;
@@ -13,7 +15,7 @@ namespace StyleChecker.Refactoring.NotDesignedForExtension
     /// NotDesignedForExtension analyzer.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class Analyzer : DiagnosticAnalyzer
+    public sealed class Analyzer : AbstractAnalyzer
     {
         /// <summary>
         /// The ID of this analyzer.
@@ -28,10 +30,8 @@ namespace StyleChecker.Refactoring.NotDesignedForExtension
             SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+        private protected override void Register(AnalysisContext context)
         {
-            context.ConfigureGeneratedCodeAnalysis(
-                GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
             context.RegisterSemanticModelAction(AnalyzeModel);
         }
@@ -100,7 +100,7 @@ namespace StyleChecker.Refactoring.NotDesignedForExtension
             return node is null ? default : node.Identifier;
         }
 
-        private static T ToNode<T>(ISymbol m)
+        private static T? ToNode<T>(ISymbol m)
             where T : SyntaxNode
         {
             var reference = m.DeclaringSyntaxReferences.FirstOrDefault();
@@ -109,11 +109,11 @@ namespace StyleChecker.Refactoring.NotDesignedForExtension
 
         private static bool IsEmpty(IMethodSymbol m)
         {
-            bool HasNoBlock(MethodDeclarationSyntax n)
+            static bool HasNoBlock(MethodDeclarationSyntax n)
                 => n.Body is null
                     && n.ExpressionBody is null;
 
-            bool HasAnEmptyBlock(MethodDeclarationSyntax n)
+            static bool HasAnEmptyBlock(MethodDeclarationSyntax n)
                 => n.Body is BlockSyntax block
                     && !block.Statements.Any();
 

--- a/StyleChecker/StyleChecker/Refactoring/StaticGenericClass/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Refactoring/StaticGenericClass/Analyzer.cs
@@ -12,7 +12,7 @@ namespace StyleChecker.Refactoring.StaticGenericClass
     /// StaticGenericClass analyzer.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class Analyzer : DiagnosticAnalyzer
+    public sealed class Analyzer : AbstractAnalyzer
     {
         /// <summary>
         /// The ID of this analyzer.
@@ -27,10 +27,8 @@ namespace StyleChecker.Refactoring.StaticGenericClass
             SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+        private protected override void Register(AnalysisContext context)
         {
-            context.ConfigureGeneratedCodeAnalysis(
-                GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
             context.RegisterSemanticModelAction(AnalyzeModel);
         }

--- a/StyleChecker/StyleChecker/Refactoring/TypeClassParameter/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Refactoring/TypeClassParameter/Analyzer.cs
@@ -15,7 +15,7 @@ namespace StyleChecker.Refactoring.TypeClassParameter
     /// TypeClassParameter analyzer.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class Analyzer : DiagnosticAnalyzer
+    public sealed class Analyzer : AbstractAnalyzer
     {
         /// <summary>
         /// The ID of this analyzer.
@@ -30,10 +30,8 @@ namespace StyleChecker.Refactoring.TypeClassParameter
             SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+        private protected override void Register(AnalysisContext context)
         {
-            context.ConfigureGeneratedCodeAnalysis(
-                GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
             context.RegisterCompilationStartAction(StartAction);
         }
@@ -64,7 +62,7 @@ namespace StyleChecker.Refactoring.TypeClassParameter
         private static bool IsEveryArgumentTypeofOperator(
              IEnumerable<IInvocationOperation> invocations, int i)
         {
-            bool IsNonStaticTypeofOperation(IOperation o)
+            static bool IsNonStaticTypeofOperation(IOperation o)
                 => o is ITypeOfOperation typeOfOperation
                     && !typeOfOperation.TypeOperand.IsStatic;
 
@@ -82,7 +80,7 @@ namespace StyleChecker.Refactoring.TypeClassParameter
             List<IMethodSymbol> globalMethods,
             List<IInvocationOperation> globalInvocations)
         {
-            ImmutableArray<T> ToImmutableArray<T>(IEnumerable<T> a)
+            static ImmutableArray<T> ToImmutableArray<T>(IEnumerable<T> a)
             {
                 lock (a)
                 {
@@ -132,7 +130,7 @@ namespace StyleChecker.Refactoring.TypeClassParameter
             List<IMethodSymbol> globalMethods,
             List<IInvocationOperation> globalInvocations)
         {
-            bool HasTypeClassParameter(IMethodSymbol m)
+            static bool HasTypeClassParameter(IMethodSymbol m)
                 => TypeClassParameters(m).Any();
 
             var operationSupplier = context.GetOperationSupplier();

--- a/StyleChecker/StyleChecker/Settings/ConfigBank.cs
+++ b/StyleChecker/StyleChecker/Settings/ConfigBank.cs
@@ -38,13 +38,14 @@ namespace StyleChecker.Settings
             CompilationStartAnalysisContext context)
         {
             var (path, source) = LoadConfigFile(context);
-            if (source is null)
+            if (path is null || source is null)
             {
                 return new ConfigPod(DefaultRootConfig, null, null);
             }
             lock (PodMap)
             {
-                if (!PodMap.TryGetValue(source, out var pod))
+                var pod = PodMap.Get(source);
+                if (pod is null)
                 {
                     pod = NewRootConfig(path, source);
                     PodMap.Put(source, pod);
@@ -90,7 +91,7 @@ namespace StyleChecker.Settings
             }
         }
 
-        private static (string, string) LoadConfigFile(
+        private static (string?, string?) LoadConfigFile(
             CompilationStartAnalysisContext c)
         {
             var additionalFiles = c.Options.AdditionalFiles;

--- a/StyleChecker/StyleChecker/Settings/ConfigPod.cs
+++ b/StyleChecker/StyleChecker/Settings/ConfigPod.cs
@@ -23,8 +23,8 @@ namespace StyleChecker.Settings
         /// </param>
         public ConfigPod(
             RootConfig rootConfig,
-            Exception exception,
-            string path)
+            Exception? exception,
+            string? path)
         {
             RootConfig = rootConfig;
             Exception = exception;
@@ -39,11 +39,11 @@ namespace StyleChecker.Settings
         /// <summary>
         /// Gets the exception if any.
         /// </summary>
-        public Exception Exception { get; }
+        public Exception? Exception { get; }
 
         /// <summary>
         /// Gets the path of the configuration file.
         /// </summary>
-        public string Path { get; }
+        public string? Path { get; }
     }
 }

--- a/StyleChecker/StyleChecker/Settings/InvalidConfig/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Settings/InvalidConfig/Analyzer.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS8619
+
 namespace StyleChecker.Settings.InvalidConfig
 {
     using System.Collections.Immutable;
@@ -12,7 +14,7 @@ namespace StyleChecker.Settings.InvalidConfig
     /// InvalidConfig analyzer.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class Analyzer : DiagnosticAnalyzer
+    public sealed class Analyzer : AbstractAnalyzer
     {
         /// <summary>
         /// The ID of this analyzer.
@@ -27,10 +29,8 @@ namespace StyleChecker.Settings.InvalidConfig
             SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+        private protected override void Register(AnalysisContext context)
         {
-            context.ConfigureGeneratedCodeAnalysis(
-                GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
             context.RegisterCompilationStartAction(StartAction);
         }

--- a/StyleChecker/StyleChecker/Settings/WeakValueMap.cs
+++ b/StyleChecker/StyleChecker/Settings/WeakValueMap.cs
@@ -48,7 +48,7 @@ namespace StyleChecker.Settings
         /// <c>true</c> if this contains an element with the specified key;
         /// otherwise, <c>false</c>.
         /// </returns>
-        public bool TryGetValue(K key, out V value)
+        public bool TryGetValue(K key, out V? value)
         {
             ClearGabageKeys();
             if (map.TryGetValue(key, out var weakRef)
@@ -58,6 +58,25 @@ namespace StyleChecker.Settings
             }
             value = null;
             return false;
+        }
+
+        /// <summary>
+        /// Gets the value associated with the specified key.
+        /// </summary>
+        /// <param name="key">
+        /// The key of the value to get.
+        /// </param>
+        /// <returns>
+        /// The value associated with the specified key, if the key is found;
+        /// otherwise, <c>null</c>.
+        /// </returns>
+        public V? Get(K key)
+        {
+            ClearGabageKeys();
+            return map.TryGetValue(key, out var weakRef)
+                   && weakRef.TryGetTarget(out var value)
+                ? value
+                : null;
         }
 
         /// <summary>

--- a/StyleChecker/StyleChecker/Spacing/NoSingleSpaceAfterTripleSlash/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Spacing/NoSingleSpaceAfterTripleSlash/Analyzer.cs
@@ -12,7 +12,7 @@ namespace StyleChecker.Spacing.NoSingleSpaceAfterTripleSlash
     /// NoSingleSpaceAfterTripleSlash analyzer.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class Analyzer : DiagnosticAnalyzer
+    public sealed class Analyzer : AbstractAnalyzer
     {
         /// <summary>
         /// The ID of this analyzer.
@@ -28,10 +28,8 @@ namespace StyleChecker.Spacing.NoSingleSpaceAfterTripleSlash
             SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+        private protected override void Register(AnalysisContext context)
         {
-            context.ConfigureGeneratedCodeAnalysis(
-                GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
             context.RegisterSyntaxTreeAction(SyntaxTreeAction);
         }

--- a/StyleChecker/StyleChecker/Spacing/NoSingleSpaceAfterTripleSlash/CodeFixer.cs
+++ b/StyleChecker/StyleChecker/Spacing/NoSingleSpaceAfterTripleSlash/CodeFixer.cs
@@ -82,7 +82,7 @@ namespace StyleChecker.Spacing.NoSingleSpaceAfterTripleSlash
                     replaceFixTitle,
                     c => ReplaceTriviaTask(document, root, token, trivia));
 
-            CodeAction GetAction()
+            CodeAction? GetAction()
             {
                 if (token.Kind() is SyntaxKind.XmlTextLiteralToken
                     && node is XmlTextSyntax)

--- a/StyleChecker/StyleChecker/Spacing/NoSpaceAfterSemicolon/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Spacing/NoSpaceAfterSemicolon/Analyzer.cs
@@ -11,7 +11,7 @@ namespace StyleChecker.Spacing.NoSpaceAfterSemicolon
     /// NoSpaceAfterSemicolon analyzer.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class Analyzer : DiagnosticAnalyzer
+    public sealed class Analyzer : AbstractAnalyzer
     {
         /// <summary>
         /// The ID of this analyzer.
@@ -26,10 +26,8 @@ namespace StyleChecker.Spacing.NoSpaceAfterSemicolon
             SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+        private protected override void Register(AnalysisContext context)
         {
-            context.ConfigureGeneratedCodeAnalysis(
-                GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
             context.RegisterSyntaxTreeAction(SyntaxTreeAction);
         }

--- a/StyleChecker/StyleChecker/Spacing/SpaceBeforeSemicolon/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Spacing/SpaceBeforeSemicolon/Analyzer.cs
@@ -11,7 +11,7 @@ namespace StyleChecker.Spacing.SpaceBeforeSemicolon
     /// SpaceBeforeSemicolon analyzer.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class Analyzer : DiagnosticAnalyzer
+    public sealed class Analyzer : AbstractAnalyzer
     {
         /// <summary>
         /// The ID of this analyzer.
@@ -26,10 +26,8 @@ namespace StyleChecker.Spacing.SpaceBeforeSemicolon
             SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+        private protected override void Register(AnalysisContext context)
         {
-            context.ConfigureGeneratedCodeAnalysis(
-                GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
             context.RegisterSyntaxTreeAction(SyntaxTreeAction);
         }

--- a/StyleChecker/StyleChecker/Spacing/SpaceBeforeSemicolon/CodeFixer.cs
+++ b/StyleChecker/StyleChecker/Spacing/SpaceBeforeSemicolon/CodeFixer.cs
@@ -56,7 +56,7 @@ namespace StyleChecker.Spacing.SpaceBeforeSemicolon
             SyntaxNode root,
             SyntaxToken token)
         {
-            SyntaxTriviaList Trim(SyntaxTriviaList triviaList)
+            static SyntaxTriviaList Trim(SyntaxTriviaList triviaList)
             {
                 var list = triviaList;
                 var target = list.Last();

--- a/StyleChecker/StyleChecker/StyleChecker.csproj
+++ b/StyleChecker/StyleChecker/StyleChecker.csproj
@@ -22,6 +22,7 @@
     <RepositoryType />
     <Company>Maroontress Fast Software</Company>
     <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
     <AnnotationsVersion>1.0.1</AnnotationsVersion>
     <OxbindVersion>1.0.3</OxbindVersion>
   </PropertyGroup>

--- a/StyleChecker/StyleChecker/Syntaxes.cs
+++ b/StyleChecker/StyleChecker/Syntaxes.cs
@@ -71,7 +71,7 @@ namespace StyleChecker
         /// <returns>
         /// The node if found, <c>null</c> otherwise.
         /// </returns>
-        public static T FindNodeOfType<T>(
+        public static T? FindNodeOfType<T>(
             this SyntaxNode root, TextSpan span)
             where T : SyntaxNode
         {


### PR DESCRIPTION
- Add XML Documentation Comments.
- Make local functions static.
- Replace string.Join() with string.Concat().
- Replace Select().Max() with Max().
- Replace the using statement with using var.
- Optimize if statements.
- Replace @"" with "".
- Fix to handle nullable types.