### PR TITLE
Fix StaticGenericClass analyzer and CodeFix provider.

### DIFF
--- a/StyleChecker/StyleChecker.Test/Refactoring/StaticGenericClass/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/StaticGenericClass/AnalyzerTest.cs
@@ -51,5 +51,24 @@ namespace StyleChecker.Test.Refactoring.StaticGenericClass
             var fix = ReadText("MultiTypeParamCodeFix");
             VerifyFix(code, fix);
         }
+
+        [TestMethod]
+        public void RenameCode()
+        {
+            var code = ReadText("RenameCode");
+            var fix = ReadText("RenameCodeFix");
+            VerifyFix(code, fix);
+        }
+
+        [TestMethod]
+        public void RenameCodeWithReferences()
+        {
+            var codeChangeList = new[]
+            {
+                ReadCodeChange("RenameReferencedCode"),
+                ReadCodeChange("RenameReferencingCode"),
+            };
+            VerifyFix(codeChangeList);
+        }
     }
 }

--- a/StyleChecker/StyleChecker.Test/Refactoring/StaticGenericClass/RenameCode.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/StaticGenericClass/RenameCode.cs
@@ -1,0 +1,32 @@
+#pragma warning disable CS0693
+
+namespace StyleChecker.Test.Refactoring.StaticGenericClass
+{
+    public static class RenameCode<T>
+        where T : class
+    {
+        public static void Method(T instance)
+        {
+        }
+    }
+
+    public static class RenameCode
+    {
+    }
+
+    public static class System<T>
+        where T : class
+    {
+        public static void Method(T instance)
+        {
+        }
+    }
+
+    public static class String<T>
+        where T : class
+    {
+        public static void Method(T instance)
+        {
+        }
+    }
+}

--- a/StyleChecker/StyleChecker.Test/Refactoring/StaticGenericClass/RenameCodeFix.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/StaticGenericClass/RenameCodeFix.cs
@@ -1,0 +1,29 @@
+#pragma warning disable CS0693
+
+namespace StyleChecker.Test.Refactoring.StaticGenericClass
+{
+    public static class RenameCode_1
+    {
+        public static void Method<T>(T instance) where T : class
+        {
+        }
+    }
+
+    public static class RenameCode
+    {
+    }
+
+    public static class System_1
+    {
+        public static void Method<T>(T instance) where T : class
+        {
+        }
+    }
+
+    public static class String_1
+    {
+        public static void Method<T>(T instance) where T : class
+        {
+        }
+    }
+}

--- a/StyleChecker/StyleChecker.Test/Refactoring/StaticGenericClass/RenameReferencedCode.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/StaticGenericClass/RenameReferencedCode.cs
@@ -1,0 +1,17 @@
+#pragma warning disable CS0693
+
+namespace StyleChecker.Test.Refactoring.StaticGenericClass
+{
+    public static class ReferencedCode<T>
+    {
+        public static void Method(T instance)
+        {
+        }
+
+        public static T Identity(T instance) => instance;
+    }
+
+    public sealed class ReferencedCode_1
+    {
+    }
+}

--- a/StyleChecker/StyleChecker.Test/Refactoring/StaticGenericClass/RenameReferencedCodeFix.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/StaticGenericClass/RenameReferencedCodeFix.cs
@@ -1,0 +1,17 @@
+#pragma warning disable CS0693
+
+namespace StyleChecker.Test.Refactoring.StaticGenericClass
+{
+    public static class ReferencedCode_2
+    {
+        public static void Method<T>(T instance)
+        {
+        }
+
+        public static T Identity<T>(T instance) => instance;
+    }
+
+    public sealed class ReferencedCode_1
+    {
+    }
+}

--- a/StyleChecker/StyleChecker.Test/Refactoring/StaticGenericClass/RenameReferencingCode.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/StaticGenericClass/RenameReferencingCode.cs
@@ -1,0 +1,25 @@
+#pragma warning disable CS0693
+
+namespace StyleChecker.Test.Refactoring.StaticGenericClass
+{
+    using System.Linq;
+
+    public static class ReferencingCode
+    {
+        public static void Method()
+        {
+            ReferencedCode<string>.Method("string");
+            ReferencedCode<System.Type>.Method(typeof(string));
+            var type = typeof(ReferencedCode<object>);
+            System.Action<string> m = ReferencedCode<string>.Method;
+
+            string[] inArray = { "a", "b", "c" };
+            var outArray = inArray.Select(ReferencedCode<string>.Identity)
+                .ToArray();
+        }
+    }
+
+    public sealed class ReferencedCode
+    {
+    }
+}

--- a/StyleChecker/StyleChecker.Test/Refactoring/StaticGenericClass/RenameReferencingCodeFix.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/StaticGenericClass/RenameReferencingCodeFix.cs
@@ -1,0 +1,25 @@
+#pragma warning disable CS0693
+
+namespace StyleChecker.Test.Refactoring.StaticGenericClass
+{
+    using System.Linq;
+
+    public static class ReferencingCode
+    {
+        public static void Method()
+        {
+            ReferencedCode_2.Method("string");
+            ReferencedCode_2.Method(typeof(string));
+            var type = typeof(ReferencedCode_2);
+            System.Action<string> m = ReferencedCode_2.Method;
+
+            string[] inArray = { "a", "b", "c" };
+            var outArray = inArray.Select(ReferencedCode_2.Identity)
+                .ToArray();
+        }
+    }
+
+    public sealed class ReferencedCode
+    {
+    }
+}

--- a/StyleChecker/StyleChecker.Test/StyleChecker.Test.csproj
+++ b/StyleChecker/StyleChecker.Test/StyleChecker.Test.csproj
@@ -65,6 +65,12 @@
     <Compile Remove="Refactoring\StaticGenericClass\ReferencedCodeFix.cs" />
     <Compile Remove="Refactoring\StaticGenericClass\ReferencingCode.cs" />
     <Compile Remove="Refactoring\StaticGenericClass\ReferencingCodeFix.cs" />
+    <Compile Remove="Refactoring\StaticGenericClass\RenameCode.cs" />
+    <Compile Remove="Refactoring\StaticGenericClass\RenameCodeFix.cs" />
+    <Compile Remove="Refactoring\StaticGenericClass\RenameReferencedCode.cs" />
+    <Compile Remove="Refactoring\StaticGenericClass\RenameReferencedCodeFix.cs" />
+    <Compile Remove="Refactoring\StaticGenericClass\RenameReferencingCode.cs" />
+    <Compile Remove="Refactoring\StaticGenericClass\RenameReferencingCodeFix.cs" />
     <Compile Remove="Refactoring\TypeClassParameter\Code.cs" />
     <Compile Remove="Refactoring\TypeClassParameter\CodeFix.cs" />
     <Compile Remove="Refactoring\TypeClassParameter\Okay.cs" />
@@ -242,6 +248,24 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Refactoring\EmptyArrayCreation\Okay.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Refactoring\StaticGenericClass\RenameReferencingCodeFix.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Refactoring\StaticGenericClass\RenameReferencingCode.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Refactoring\StaticGenericClass\RenameReferencedCodeFix.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Refactoring\StaticGenericClass\RenameReferencedCode.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Refactoring\StaticGenericClass\RenameCodeFix.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Refactoring\StaticGenericClass\RenameCode.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Refactoring\StaticGenericClass\ReferencedCode.cs">


### PR DESCRIPTION
- Fix the code fix provider to rename the type name to the unique name
  when the other type that has the same name already exists.