### PR TITLE
Fix Underscore analyzer.

### DIFF
--- a/StyleChecker/StyleChecker.Test/Naming/Underscore/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Naming/Underscore/AnalyzerTest.cs
@@ -28,7 +28,9 @@ namespace StyleChecker.Test.Naming.Underscore
 
             static Result Expected(Belief b) => b.ToResult(
                 Analyzer.DiagnosticId,
-                m => $"The name '{m}' includes a underscore.");
+                m => m is "_"
+                    ? $"The name '_' is just an underscore, not a discard."
+                    : $"The name '{m}' includes an underscore.");
 
             VerifyDiagnosticAndFix(code, Atmosphere.Default, Expected, fix);
         }

--- a/StyleChecker/StyleChecker.Test/Naming/Underscore/Code.cs
+++ b/StyleChecker/StyleChecker.Test/Naming/Underscore/Code.cs
@@ -49,6 +49,8 @@ namespace Application
             {
                 Console.WriteLine($"{_o}");
             }
+            Func<int, int> identity = (_) => _;
+            //@                        ^_
         }
 
         public void Catch()

--- a/StyleChecker/StyleChecker.Test/Naming/Underscore/CodeFix.cs
+++ b/StyleChecker/StyleChecker.Test/Naming/Underscore/CodeFix.cs
@@ -34,6 +34,7 @@ namespace Application
             {
                 Console.WriteLine($"{o}");
             }
+            Func<int, int> identity = (underscore) => underscore;
         }
 
         public void Catch()

--- a/StyleChecker/StyleChecker.Test/Naming/Underscore/Okay.cs
+++ b/StyleChecker/StyleChecker.Test/Naming/Underscore/Okay.cs
@@ -12,5 +12,26 @@ namespace Application
             void Out(out int x) => x = 3;
             Out(out _);
         }
+
+        public void SwitchPatternMatching(object o)
+        {
+            switch (o)
+            {
+                case string _:
+                    break;
+                case object _:
+                    break;
+            }
+        }
+
+        public void IsPatternMatching(object o)
+        {
+            if (o is string _)
+            {
+            }
+            else if (o is object _)
+            {
+            }
+        }
     }
 }

--- a/StyleChecker/StyleChecker/Naming/Underscore/Analyzer.cs
+++ b/StyleChecker/StyleChecker/Naming/Underscore/Analyzer.cs
@@ -19,11 +19,14 @@ namespace StyleChecker.Naming.Underscore
         public const string DiagnosticId = "Underscore";
 
         private const string Category = Categories.Naming;
-        private static readonly DiagnosticDescriptor Rule = NewRule();
+        private static readonly DiagnosticDescriptor IsRule = NewIsRule();
+        private static readonly DiagnosticDescriptor IncludeRule
+            = NewIncludeRule();
 
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor>
-            SupportedDiagnostics => ImmutableArray.Create(Rule);
+                SupportedDiagnostics
+            => ImmutableArray.Create(IncludeRule, IsRule);
 
         /// <inheritdoc/>
         private protected override void Register(AnalysisContext context)
@@ -32,13 +35,19 @@ namespace StyleChecker.Naming.Underscore
             context.RegisterSyntaxTreeAction(AnalyzeSyntaxTree);
         }
 
-        private static DiagnosticDescriptor NewRule()
+        private static DiagnosticDescriptor NewIncludeRule()
+            => NewRule(nameof(R.IncludeMessageFormat));
+
+        private static DiagnosticDescriptor NewIsRule()
+            => NewRule(nameof(R.IsMessageFormat));
+
+        private static DiagnosticDescriptor NewRule(string messageFormat)
         {
             var localize = Localizers.Of<R>(R.ResourceManager);
             return new DiagnosticDescriptor(
                 DiagnosticId,
                 localize(nameof(R.Title)),
-                localize(nameof(R.MessageFormat)),
+                localize(messageFormat),
                 Category,
                 DiagnosticSeverity.Warning,
                 isEnabledByDefault: true,
@@ -71,7 +80,7 @@ namespace StyleChecker.Naming.Underscore
             foreach (var token in all)
             {
                 var diagnostic = Diagnostic.Create(
-                    Rule,
+                    (token.ValueText is "_") ? IsRule : IncludeRule,
                     token.GetLocation(),
                     token);
                 context.ReportDiagnostic(diagnostic);

--- a/StyleChecker/StyleChecker/Naming/Underscore/Resources.Designer.cs
+++ b/StyleChecker/StyleChecker/Naming/Underscore/Resources.Designer.cs
@@ -20,7 +20,7 @@ namespace StyleChecker.Naming.Underscore {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -80,11 +80,20 @@ namespace StyleChecker.Naming.Underscore {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The name &apos;{0}&apos; includes a underscore..
+        ///   Looks up a localized string similar to The name &apos;{0}&apos; includes an underscore..
         /// </summary>
-        internal static string MessageFormat {
+        internal static string IncludeMessageFormat {
             get {
-                return ResourceManager.GetString("MessageFormat", resourceCulture);
+                return ResourceManager.GetString("IncludeMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The name &apos;_&apos; is just an underscore, not a discard..
+        /// </summary>
+        internal static string IsMessageFormat {
+            get {
+                return ResourceManager.GetString("IsMessageFormat", resourceCulture);
             }
         }
         

--- a/StyleChecker/StyleChecker/Naming/Underscore/Resources.resx
+++ b/StyleChecker/StyleChecker/Naming/Underscore/Resources.resx
@@ -123,8 +123,11 @@
   <data name="FixTitle" xml:space="preserve">
     <value>Remove all underscores.</value>
   </data>
-  <data name="MessageFormat" xml:space="preserve">
-    <value>The name '{0}' includes a underscore.</value>
+  <data name="IncludeMessageFormat" xml:space="preserve">
+    <value>The name '{0}' includes an underscore.</value>
+  </data>
+  <data name="IsMessageFormat" xml:space="preserve">
+    <value>The name '_' is just an underscore, not a discard.</value>
   </data>
   <data name="Title" xml:space="preserve">
     <value>The name of local variables must not include underscores.</value>


### PR DESCRIPTION
- Add test cases to check whether the analyzer ignores Discards in the
  pattern matching.
- Fix typo in the diagnostic messages.
- Improve diagnostic messages, especially just for the underscore that
  is not a discard.