### PR TITLE
Fix TypeClassParameter analyzer.

### DIFF
--- a/StyleChecker/StyleChecker.Test/Refactoring/TypeClassParameter/AnalyzerTest.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/TypeClassParameter/AnalyzerTest.cs
@@ -1,6 +1,7 @@
 namespace StyleChecker.Test.Refactoring.TypeClassParameter
 {
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StyleChecker.Refactoring.TypeClassParameter;
     using StyleChecker.Test.Framework;
@@ -8,6 +9,13 @@ namespace StyleChecker.Test.Refactoring.TypeClassParameter
     [TestClass]
     public sealed class AnalyzerTest : CodeFixVerifier
     {
+        private static readonly ImmutableDictionary<string, string> KindSet
+            = new Dictionary<string, string>()
+            {
+                ["L"] = "local function",
+                ["M"] = "method",
+            }.ToImmutableDictionary();
+
         public AnalyzerTest()
             : base(new Analyzer(), new CodeFixer())
         {
@@ -20,25 +28,17 @@ namespace StyleChecker.Test.Refactoring.TypeClassParameter
         [TestMethod]
         public void Code()
         {
-            var kindSet = new Dictionary<string, string>()
-            {
-                ["L"] = "local function",
-                ["M"] = "method",
-            };
             var code = ReadText("Code");
             var fix = ReadText("CodeFix");
-            Result Expected(Belief b)
-            {
-                var array = b.Message.Split(',');
-                var parameterName = array[0];
-                var functionKind = kindSet[array[1]];
-                var functionName = array[2];
-                return b.ToResult(
-                    Analyzer.DiagnosticId,
-                    $"The parameter '{parameterName}' of the {functionKind} "
-                    + $"'{functionName}' must be replaced with the type "
-                    + $"parameter.");
-            }
+
+            VerifyDiagnosticAndFix(code, Atmosphere.Default, Expected, fix);
+        }
+
+        [TestMethod]
+        public void RenameCode()
+        {
+            var code = ReadText("RenameCode");
+            var fix = ReadText("RenameCodeFix");
 
             VerifyDiagnosticAndFix(code, Atmosphere.Default, Expected, fix);
         }
@@ -52,6 +52,19 @@ namespace StyleChecker.Test.Refactoring.TypeClassParameter
                 ReadCodeChange("ReferencingCode"),
             };
             VerifyFix(codeChangeList);
+        }
+
+        private static Result Expected(Belief b)
+        {
+            var array = b.Message.Split(',');
+            var parameterName = array[0];
+            var functionKind = KindSet[array[1]];
+            var functionName = array[2];
+            return b.ToResult(
+                Analyzer.DiagnosticId,
+                $"The parameter '{parameterName}' of the {functionKind} "
+                + $"'{functionName}' must be replaced with the type "
+                + $"parameter.");
         }
     }
 }

--- a/StyleChecker/StyleChecker.Test/Refactoring/TypeClassParameter/RenameCode.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/TypeClassParameter/RenameCode.cs
@@ -1,0 +1,24 @@
+#pragma warning disable CS8019
+
+namespace StyleChecker.Test.Refactoring.TypeClassParameter
+{
+    using System;
+
+    public sealed class RenameCode
+    {
+        private void PrintMethod<T>()
+        {
+        }
+
+        private void PrintMethod(Type type)
+        //@                           ^type,M,PrintMethod
+        {
+        }
+
+        public void CallWithStringType()
+        {
+            PrintMethod(typeof(string));
+            PrintMethod<int>();
+        }
+    }
+}

--- a/StyleChecker/StyleChecker.Test/Refactoring/TypeClassParameter/RenameCodeFix.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/TypeClassParameter/RenameCodeFix.cs
@@ -1,0 +1,24 @@
+#pragma warning disable CS8019
+
+namespace StyleChecker.Test.Refactoring.TypeClassParameter
+{
+    using System;
+
+    public sealed class RenameCode
+    {
+        private void PrintMethod_0<T>()
+        {
+        }
+
+        private void PrintMethod<T>()
+        {
+            var type = typeof(T);
+        }
+
+        public void CallWithStringType()
+        {
+            PrintMethod<string>();
+            PrintMethod_0<int>();
+        }
+    }
+}

--- a/StyleChecker/StyleChecker.Test/StyleChecker.Test.csproj
+++ b/StyleChecker/StyleChecker.Test/StyleChecker.Test.csproj
@@ -78,6 +78,8 @@
     <Compile Remove="Refactoring\TypeClassParameter\ReferencedCodeFix.cs" />
     <Compile Remove="Refactoring\TypeClassParameter\ReferencingCode.cs" />
     <Compile Remove="Refactoring\TypeClassParameter\ReferencingCodeFix.cs" />
+    <Compile Remove="Refactoring\TypeClassParameter\RenameCode.cs" />
+    <Compile Remove="Refactoring\TypeClassParameter\RenameCodeFix.cs" />
     <Compile Remove="Refactoring\UnnecessaryUsing\Code.cs" />
     <Compile Remove="Refactoring\UnnecessaryUsing\CodeFix.cs" />
     <Compile Remove="Settings\InvalidConfig\Code.cs" />
@@ -293,6 +295,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Refactoring\StaticGenericClass\ReferencingCodeFix.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Refactoring\TypeClassParameter\RenameCodeFix.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Refactoring\TypeClassParameter\RenameCode.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Refactoring\TypeClassParameter\ReferencedCode.cs">

--- a/doc/rules/TypeClassParameter.md
+++ b/doc/rules/TypeClassParameter.md
@@ -62,6 +62,14 @@ invokes the original version of `Print` with an argument other than the
 `typeof()` operator whose operand is not a `static` class, because it is
 unable to replace the parameter `type` with a type parameter `T`.
 
+> ### Restriction
+>
+> This analyzer can only diagnose local functions and private methods
+> with the Visual Studio 2019 editor.
+> To diagnose non-private methods with Visual Studio 2019,
+> perform Build Solution or Analysis ➜ Run Code Analysis.
+
+
 ## Code fix
 
 The code fix provides the option of replacing the parameter with a type
@@ -99,6 +107,13 @@ public void Invoke()
     DoSomething<string>();
 }
 ```
+
+> ### Remarks
+>
+> If a type has both `DoSomething<T>()` and `DoSomething(Type)` methods
+> at the same time, the code fix provider renames `DoSomething<T>`
+> (to `DoSomething_0<T>`, for example) at first, and then replaces
+> `DoSomething(Type)` with `DoSomething<T>()`.
 
 [fig-TypeClassParameter]:
   https://maroontress.github.io/StyleChecker/images/TypeClassParameter.png


### PR DESCRIPTION
- Fix TCP analyzer to emit diagnostics to the private methods with the
  editor of Visual Studio 2019.
- Fix TCP code fix provider to rename the method that has the same method
  signature as the modified method.