### PR TITLE
Fix RTAC analyzer throwing NRE.

### DIFF
--- a/StyleChecker/StyleChecker.Test/Cleaning/RedundantTypedArrayCreation/Code.cs
+++ b/StyleChecker/StyleChecker.Test/Cleaning/RedundantTypedArrayCreation/Code.cs
@@ -1,5 +1,7 @@
 namespace StyleChecker.Test.Cleaning.RedundantTypedArrayCreation
 {
+    using System;
+
     public sealed class Code
     {
         public void ArgumentSyntax()
@@ -73,6 +75,26 @@ namespace StyleChecker.Test.Cleaning.RedundantTypedArrayCreation
             {
                 new[] { "a", "b" },
                 new[] { "c", "d" },
+            };
+        }
+
+        public void MethodReferencesAndDeleagte()
+        {
+            var all = new Action[]
+            //@           ^Action[]|[]
+            {
+                (Action)One,
+                Two,
+            };
+        }
+
+        public void MethodReferencesAndNull()
+        {
+            var all = new Action[]
+            //@           ^Action[]|[]
+            {
+                One,
+                (Action)null,
             };
         }
     }

--- a/StyleChecker/StyleChecker.Test/Cleaning/RedundantTypedArrayCreation/CodeFix.cs
+++ b/StyleChecker/StyleChecker.Test/Cleaning/RedundantTypedArrayCreation/CodeFix.cs
@@ -1,5 +1,7 @@
 namespace StyleChecker.Test.Cleaning.RedundantTypedArrayCreation
 {
+    using System;
+
     public sealed class Code
     {
         public void ArgumentSyntax()
@@ -62,6 +64,24 @@ namespace StyleChecker.Test.Cleaning.RedundantTypedArrayCreation
             {
                 new[] { "a", "b" },
                 new[] { "c", "d" },
+            };
+        }
+
+        public void MethodReferencesAndDeleagte()
+        {
+            var all = new[]
+            {
+                (Action)One,
+                Two,
+            };
+        }
+
+        public void MethodReferencesAndNull()
+        {
+            var all = new[]
+            {
+                One,
+                (Action)null,
             };
         }
     }

--- a/StyleChecker/StyleChecker.Test/Cleaning/RedundantTypedArrayCreation/Okay.cs
+++ b/StyleChecker/StyleChecker.Test/Cleaning/RedundantTypedArrayCreation/Okay.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace StyleChecker.Test.Cleaning.RedundantTypedArrayCreation
 {
     public sealed class Okay
@@ -35,6 +37,24 @@ namespace StyleChecker.Test.Cleaning.RedundantTypedArrayCreation
         public void FixedLengthArray()
         {
             var all = new string[3];
+        }
+
+        public void MethodReferences()
+        {
+            var all = new Action[]
+            {
+                Complex,
+                Empty,
+            };
+        }
+
+        public void MethodReferencesWithNull()
+        {
+            var all = new Action[]
+            {
+                Complex,
+                null,
+            };
         }
     }
 }

--- a/doc/rules/RedundantTypedArrayCreation.md
+++ b/doc/rules/RedundantTypedArrayCreation.md
@@ -27,6 +27,29 @@ initializer. Note that
 > You can create an implicitly-typed array in which the type of the array
 > instance is inferred from the elements specified in the array initializer.
 
+### Remarks
+
+There are some cases where type inference does not work so that the
+implicitly-typed arrays are not available.
+For example, when all the elements are Method References, the implicitly-typed
+array creation causes an error CS0826 as follows:
+
+```csharp
+public static void RaiseCS0826()
+{
+    _ = new[]
+    {
+        DoSomething,
+    };
+}
+
+public static void DoSomething()
+{
+}
+```
+
+> [See errors][sharplab:examples]
+
 ## Code fix
 
 The code fix provides an option removing the explicit type of the array.
@@ -56,9 +79,11 @@ public void Method()
 ## References
 
 <a id="ref1"></a>
-[1] [Microsoft, _Implicitly Typed Arrays (C# Reference)_][implicitly-typed-arrays-microsoft]
+[1] [Microsoft, _Implicitly Typed Arrays (C# Programming Guide)_][microsoft:csharp-implicitly-typed-arrays]
 
-[implicitly-typed-arrays-microsoft]:
+[microsoft:csharp-implicitly-typed-arrays]:
   https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/arrays/implicitly-typed-arrays
+[sharplab:examples]:
+  https://sharplab.io/#v2:C4LghgzsA0AmIGoA+ABATARgLAChcoGYACFDANhLSIFEAPMAWwAcAbAUwlwG9ci+TipCigAsRACoBPJmwCSAOwBmbAE5t5AYzkQAcgHtgAQQBuYAJYswAI3YAKAJS9+PHPzdEA9B6KGWLImzsDOrAEERgakTAABZsRMExerBEaspqmhwAdE7uRAD6RAC8RPJsAO4kGGgA2gC6Oe4uubkAInoAynoJ0WbyAObQDW4AvgDcDcO4DYSVwmJSMgpp6lqyECbmljZsDg1NzV4+wETskMd6pQFBIURmYWBEsIFsfWDAbNmuzQXFpWV1Q2cgNytlIaHsbU63V6A2B7khXTYMRhgy+uTGEymaIEsxIYgASuYIGwAMLtAAMAA40GRdtj9rkfiVygDsW4Gc0+Ajof1UZyMdjJtjpoJyHiiNykT1+nT2ZicEKgA
 [fig-RedundantTypedArrayCreation]:
   https://maroontress.github.io/StyleChecker/images/RedundantTypedArrayCreation.png


### PR DESCRIPTION
- Fix RTAC analyzer to ignore the array creation where all the elements
  are method references.