### PR TITLE
Fix NCAD analyzer

### DIFF
--- a/StyleChecker/StyleChecker.Test/Refactoring/NullCheckAfterDeclaration/Okay.cs
+++ b/StyleChecker/StyleChecker.Test/Refactoring/NullCheckAfterDeclaration/Okay.cs
@@ -31,4 +31,20 @@ public sealed class Okay
         {
         }
     }
+
+    public static void InitialValueIsNonNullableValueType()
+    {
+        int? i = 0;
+        if (i is not null)
+        {
+            _ = i.Value;
+        }
+
+#pragma warning disable CS0472
+        int a = 0;
+        if (a != null)
+        {
+        }
+#pragma warning restore CS0472
+    }
 }

--- a/StyleChecker/StyleChecker/Refactoring/ISymbolizer.cs
+++ b/StyleChecker/StyleChecker/Refactoring/ISymbolizer.cs
@@ -294,4 +294,15 @@ public interface ISymbolizer
     /// The symbol representing the variable.
     /// </returns>
     ISymbol? ToSymbol(VariableDeclaratorSyntax node);
+
+    /// <summary>
+    /// Gets the operation corresponding to the specified syntax node.
+    /// </summary>
+    /// <param name="node">
+    /// The syntax node.
+    /// </param>
+    /// <returns>
+    /// The operation representing the syntax node.
+    /// </returns>
+    IOperation? GetOperation(SyntaxNode node);
 }

--- a/StyleChecker/StyleChecker/Refactoring/NullCheckAfterDeclaration/CodeFixer.cs
+++ b/StyleChecker/StyleChecker/Refactoring/NullCheckAfterDeclaration/CodeFixer.cs
@@ -64,12 +64,6 @@ public sealed class CodeFixer : AbstractCodeFixProvider
         context.RegisterCodeFix(action, diagnostic);
     }
 
-    private static SyntaxNode AddUsing(LocalDeclarationStatementSyntax node)
-        => node.WithoutLeadingTrivia()
-            .WithUsingKeyword(SyntaxFactory.Token(SyntaxKind.UsingKeyword))
-            .WithLeadingTrivia(node.GetLeadingTrivia())
-            .WithAdditionalAnnotations(Formatter.Annotation);
-
     private static Document? Refactor(
         Document document,
         SyntaxNode root,

--- a/StyleChecker/StyleChecker/Refactoring/SmaContextExtentions.cs
+++ b/StyleChecker/StyleChecker/Refactoring/SmaContextExtentions.cs
@@ -25,12 +25,8 @@ public static class SmaContextExtentions
     /// cref="IOperation"/> corresponding to the node.
     /// </returns>
     public static Func<SyntaxNode, IOperation?>
-        GetOperationSupplier(this SemanticModelAnalysisContext context)
-    {
-        var cancellationToken = context.CancellationToken;
-        var model = context.SemanticModel;
-        return n => model.GetOperation(n, cancellationToken);
-    }
+            GetOperationSupplier(this SemanticModelAnalysisContext context)
+        => context.GetSymbolizer().GetOperation;
 
     /// <summary>
     /// Gets the function that takes a <see cref="SyntaxNode"/> and returns the
@@ -92,6 +88,9 @@ public static class SmaContextExtentions
 
         private CancellationToken CancellationToken { get; }
             = context.CancellationToken;
+
+        public IOperation? GetOperation(SyntaxNode node)
+            => Model.GetOperation(node, CancellationToken);
 
         public IMethodSymbol? ToSymbol(AccessorDeclarationSyntax node)
             => Model.GetDeclaredSymbol(node, CancellationToken);

--- a/doc/rules/NullCheckAfterDeclaration.md
+++ b/doc/rules/NullCheckAfterDeclaration.md
@@ -38,12 +38,15 @@ Info
 ## Description
 
 This rule reports diagnostic information of the declaration of the local
-variable followed by the null check. With a declaration pattern, you can declare
-a new local variable initialized with a nullable value or reference and then
-check whether the value is `null`.
+variable followed by the null check if the initial value is a reference. With a
+declaration pattern, you can declare a new local variable initialized with a
+nullable value or reference and then check whether the value is `null`.
 
 When the local variable declaration is an explicit type declaration and has
 multiple declarators, this analyzer covers only the last variable.
+
+This analyzer does not cover cases where the declared local variables are of
+value types.
 
 Note that the default diagnostic severity of this analyzer is
 [Information][diagnostic-severity].


### PR DESCRIPTION
- Remove unused private methods
- Fix to cover only cases where the initial values are of reference types
- Add GetOperation(SyntaxNode) method to ISymbolizer interface
- Add test cases where the initial value is of value types