### PR TITLE
Fix NoSingleSpaceAfterTripleSlash analyzer

### DIFF
--- a/StyleChecker/StyleChecker.Test/Spacing/NoSingleSpaceAfterTripleSlash/Code.cs
+++ b/StyleChecker/StyleChecker.Test/Spacing/NoSingleSpaceAfterTripleSlash/Code.cs
@@ -81,5 +81,44 @@ namespace StyleChecker.Test.Spacing.NoSingleSpaceAfterTripleSlash
         private void LineBreakInsideAttributeFix()
         {
         }
+
+        public void OutsideXml()
+        {
+            ///hello
+//@            ^
+
+            ///<![CDATA[hoge]]>
+//@            ^
+        }
+
+        /// <summary>
+        ///<![CDATA[
+//@        ^
+        /// Hello, World!
+        /// ]]>
+        /// </summary>
+        public void CDataSectionBegin()
+        {
+        }
+
+        /// <summary>
+        ///  <![CDATA[
+        ///Hello, World!
+//@        ^
+        /// ]]>
+        /// </summary>
+        public void InsideCDataSection()
+        {
+        }
+
+        /// <summary>
+        /// <![CDATA[
+        /// Hello, World!
+        ///]]>
+//@        ^
+        /// </summary>
+        public void CDataSectionEnd()
+        {
+        }
     }
 }

--- a/StyleChecker/StyleChecker.Test/Spacing/NoSingleSpaceAfterTripleSlash/CodeFix.cs
+++ b/StyleChecker/StyleChecker.Test/Spacing/NoSingleSpaceAfterTripleSlash/CodeFix.cs
@@ -71,5 +71,39 @@ namespace StyleChecker.Test.Spacing.NoSingleSpaceAfterTripleSlash
         private void LineBreakInsideAttributeFix()
         {
         }
+
+        public void OutsideXml()
+        {
+            /// hello
+
+            /// <![CDATA[hoge]]>
+        }
+
+        /// <summary>
+        /// <![CDATA[
+        /// Hello, World!
+        /// ]]>
+        /// </summary>
+        public void CDataSectionBegin()
+        {
+        }
+
+        /// <summary>
+        ///  <![CDATA[
+        /// Hello, World!
+        /// ]]>
+        /// </summary>
+        public void InsideCDataSection()
+        {
+        }
+
+        /// <summary>
+        /// <![CDATA[
+        /// Hello, World!
+        /// ]]>
+        /// </summary>
+        public void CDataSectionEnd()
+        {
+        }
     }
 }


### PR DESCRIPTION
- Add test cases for NoSingleSpaceAfterTripleSlash analyzer
- Fix NoSingleSpaceAfterTripleSlash analyzer to issue a diagnostic when a component of a CDATA section starts without a space after the triple slash.