### PR TITLE
Merge v2.0.2 .. v2.0.3

### DIFF
--- a/StyleChecker/StyleChecker.Test/Spacing/NoSingleSpaceAfterTripleSlash/Code.cs
+++ b/StyleChecker/StyleChecker.Test/Spacing/NoSingleSpaceAfterTripleSlash/Code.cs
@@ -81,5 +81,44 @@ namespace StyleChecker.Test.Spacing.NoSingleSpaceAfterTripleSlash
         private void LineBreakInsideAttributeFix()
         {
         }
+
+        public void OutsideXml()
+        {
+            ///hello
+//@            ^
+
+            ///<![CDATA[hoge]]>
+//@            ^
+        }
+
+        /// <summary>
+        ///<![CDATA[
+//@        ^
+        /// Hello, World!
+        /// ]]>
+        /// </summary>
+        public void CDataSectionBegin()
+        {
+        }
+
+        /// <summary>
+        ///  <![CDATA[
+        ///Hello, World!
+//@        ^
+        /// ]]>
+        /// </summary>
+        public void InsideCDataSection()
+        {
+        }
+
+        /// <summary>
+        /// <![CDATA[
+        /// Hello, World!
+        ///]]>
+//@        ^
+        /// </summary>
+        public void CDataSectionEnd()
+        {
+        }
     }
 }

--- a/StyleChecker/StyleChecker.Test/Spacing/NoSingleSpaceAfterTripleSlash/CodeFix.cs
+++ b/StyleChecker/StyleChecker.Test/Spacing/NoSingleSpaceAfterTripleSlash/CodeFix.cs
@@ -71,5 +71,39 @@ namespace StyleChecker.Test.Spacing.NoSingleSpaceAfterTripleSlash
         private void LineBreakInsideAttributeFix()
         {
         }
+
+        public void OutsideXml()
+        {
+            /// hello
+
+            /// <![CDATA[hoge]]>
+        }
+
+        /// <summary>
+        /// <![CDATA[
+        /// Hello, World!
+        /// ]]>
+        /// </summary>
+        public void CDataSectionBegin()
+        {
+        }
+
+        /// <summary>
+        ///  <![CDATA[
+        /// Hello, World!
+        /// ]]>
+        /// </summary>
+        public void InsideCDataSection()
+        {
+        }
+
+        /// <summary>
+        /// <![CDATA[
+        /// Hello, World!
+        /// ]]>
+        /// </summary>
+        public void CDataSectionEnd()
+        {
+        }
     }
 }

--- a/StyleChecker/StyleChecker.Test/Spacing/NoSingleSpaceAfterTripleSlash/Okay.cs
+++ b/StyleChecker/StyleChecker.Test/Spacing/NoSingleSpaceAfterTripleSlash/Okay.cs
@@ -96,5 +96,53 @@ namespace StyleChecker.Test.Spacing.NoSingleSpaceAfterTripleSlash
 
             ///	 hello <see cref="world"/>
         }
+
+        /// <example>
+        /// <code><![CDATA[
+        /// Hello world
+        /// ]]></code>
+        /// </example>
+        private void CDataSection()
+        {
+        }
+
+        /// <example>
+        /// <code><![CDATA[
+        ///   <PropertyGroup>
+        ///     <TargetFramework>net8</TargetFramework>
+        ///     <LangVersion>12.0</LangVersion>
+        ///     <Nullable>enable</Nullable>
+        ///   </PropertyGroup>
+        /// ]]></code>
+        /// </example>
+        private void XmlInCDataSection()
+        {
+        }
+
+        /// <![CDATA[
+        /// Ignored
+        /// ]]>
+        private void CDataSectionOutsideXml()
+        {
+            /// <![CDATA[
+            /// Ignored
+            /// ]]>
+        }
+
+        /// <summary>Print "Hello world!"</summary>
+        /// <example>
+        /// <![CDATA[
+        /// #include <iostream>
+        ///
+        /// int main() {
+        ///     std::cout << "Hello world!" << std::endl;
+        ///
+        ///     return 0;
+        /// }
+        /// ]]>
+        /// </example>
+        private void CDataSectionContainingEmptyLineWithoutTrailingSpace()
+        {
+        }
     }
 }

--- a/StyleChecker/StyleChecker/Spacing/NoSingleSpaceAfterTripleSlash/Resources.Designer.cs
+++ b/StyleChecker/StyleChecker/Spacing/NoSingleSpaceAfterTripleSlash/Resources.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace StyleChecker.Spacing.NoSingleSpaceAfterTripleSlash {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -20,7 +19,7 @@ namespace StyleChecker.Spacing.NoSingleSpaceAfterTripleSlash {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -40,7 +39,7 @@ namespace StyleChecker.Spacing.NoSingleSpaceAfterTripleSlash {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("StyleChecker.Spacing.NoSingleSpaceAfterTripleSlash.Resources", typeof(Resources).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("StyleChecker.Spacing.NoSingleSpaceAfterTripleSlash.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -71,7 +70,7 @@ namespace StyleChecker.Spacing.NoSingleSpaceAfterTripleSlash {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Insert a single space..
+        ///   Looks up a localized string similar to Insert a single space.
         /// </summary>
         internal static string InsertFixTitle {
             get {
@@ -89,7 +88,7 @@ namespace StyleChecker.Spacing.NoSingleSpaceAfterTripleSlash {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Replace spaces with a single space..
+        ///   Looks up a localized string similar to Replace spaces with a single space.
         /// </summary>
         internal static string ReplaceFixTitle {
             get {

--- a/StyleChecker/StyleChecker/Spacing/NoSingleSpaceAfterTripleSlash/Resources.resx
+++ b/StyleChecker/StyleChecker/Spacing/NoSingleSpaceAfterTripleSlash/Resources.resx
@@ -121,13 +121,13 @@
     <value>Triple slash should be followed by a single space.</value>
   </data>
   <data name="InsertFixTitle" xml:space="preserve">
-    <value>Insert a single space.</value>
+    <value>Insert a single space</value>
   </data>
   <data name="MessageFormat" xml:space="preserve">
     <value>A single white space is needed after '///'</value>
   </data>
   <data name="ReplaceFixTitle" xml:space="preserve">
-    <value>Replace spaces with a single space.</value>
+    <value>Replace spaces with a single space</value>
   </data>
   <data name="Title" xml:space="preserve">
     <value>Triple slash is not followed by a single space.</value>


### PR DESCRIPTION
- Add test cases for NoSingleSpaceAfterTripleSlash analyzer
- Fix NoSingleSpaceAfterTripleSlash analyzer to work with CDATA sections:
  - Issue a diagnostic when a component of a CDATA section starts without a space after the triple slash
  - Ignore empty lines in CDATA sections
  - Remove the period at the end of the sentence in the Code Fix titles